### PR TITLE
ConfigPlanRepository all function should be public.

### DIFF
--- a/src/Plan/ConfigPlanRepository.php
+++ b/src/Plan/ConfigPlanRepository.php
@@ -48,7 +48,7 @@ class ConfigPlanRepository implements PlanRepository
     /**
      * @return \Laravel\Cashier\Plan\PlanCollection
      */
-    protected static function all()
+    public static function all()
     {
         $result = [];
         $defaults = config('cashier_plans.defaults');


### PR DESCRIPTION
Currently, there's no way to retrieve all plans as an object using the Cashier code. There is already a function for it, but it's protected. This pull request makes it public so developers can retrieve their plans without copying the `all` function body.