### PR TITLE
Changed the JSON-column to a TEXT-column to support more databases.

### DIFF
--- a/database/migrations/create_order_items_table.php.stub
+++ b/database/migrations/create_order_items_table.php.stub
@@ -21,7 +21,7 @@ class CreateOrderItemsTable extends Migration
             $table->string('owner_type');
             $table->unsignedInteger('owner_id');
             $table->string('description');
-            $table->json('description_extra_lines')->nullable();
+            $table->text('description_extra_lines')->nullable();
             $table->string('currency', 3);
             $table->unsignedInteger('quantity')->default(1);
             $table->integer('unit_price');


### PR DESCRIPTION
The JSON-column is not widely supported on shared-hosting environments. This pull request changes the column from a JSON-column to a TEXT-column. Laravel will cast the field to the right format.