### PR TITLE
Changed increments to bigIncrements.

### DIFF
--- a/database/migrations/create_applied_coupons_table.php.stub
+++ b/database/migrations/create_applied_coupons_table.php.stub
@@ -14,7 +14,7 @@ class CreateAppliedCouponsTable extends Migration
     public function up()
     {
         Schema::create('applied_coupons', function (Blueprint $table) {
-            $table->increments('id');
+            $table->bigIncrements('id');
             $table->unsignedInteger('redeemed_coupon_id');
             $table->morphs('model');
             $table->timestamps();

--- a/database/migrations/create_credits_table.php.stub
+++ b/database/migrations/create_credits_table.php.stub
@@ -14,7 +14,7 @@ class CreateCreditsTable extends Migration
     public function up()
     {
         Schema::create('credits', function (Blueprint $table) {
-            $table->increments('id');
+            $table->bigIncrements('id');
             $table->string('owner_type');
             $table->unsignedInteger('owner_id');
             $table->string('currency', 3);

--- a/database/migrations/create_order_items_table.php.stub
+++ b/database/migrations/create_order_items_table.php.stub
@@ -14,7 +14,7 @@ class CreateOrderItemsTable extends Migration
     public function up()
     {
         Schema::create('order_items', function (Blueprint $table) {
-            $table->increments('id');
+            $table->bigIncrements('id');
             $table->dateTime('process_at');
             $table->string('orderable_type')->nullable();
             $table->unsignedInteger('orderable_id')->nullable();

--- a/database/migrations/create_orders_table.php.stub
+++ b/database/migrations/create_orders_table.php.stub
@@ -14,7 +14,7 @@ class CreateOrdersTable extends Migration
     public function up()
     {
         Schema::create('orders', function (Blueprint $table) {
-            $table->increments('id');
+            $table->bigIncrements('id');
             $table->string('owner_type');
             $table->unsignedInteger('owner_id');
             $table->string('number');

--- a/database/migrations/create_redeemed_coupons_table.php.stub
+++ b/database/migrations/create_redeemed_coupons_table.php.stub
@@ -14,7 +14,7 @@ class CreateRedeemedCouponsTable extends Migration
     public function up()
     {
         Schema::create('redeemed_coupons', function (Blueprint $table) {
-            $table->increments('id');
+            $table->bigIncrements('id');
             $table->string('name');
             $table->string('model_type');
             $table->unsignedInteger('model_id');

--- a/database/migrations/create_subscriptions_table.php.stub
+++ b/database/migrations/create_subscriptions_table.php.stub
@@ -14,7 +14,7 @@ class CreateSubscriptionsTable extends Migration
     public function up()
     {
         Schema::create('subscriptions', function (Blueprint $table) {
-            $table->increments('id');
+            $table->bigIncrements('id');
             $table->string('name');
             $table->string('plan');
             $table->string('owner_type');


### PR DESCRIPTION
Laravel creates big integer incrementing columns by default. This pull request changes all database stubs to match the behavior. This is useful for foreign keys as the type of column must be the same as the referenced column and it matches the Laravel default behavior.