### PR TITLE
Fix changed namespace of ProvidesInvoiceInformation contract  in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Once you have pulled in the package:
     ```
     Learn more about storing data on the Mollie Customer [here](https://docs.mollie.com/reference/v2/customers-api/create-customer#parameters).
     
-    - Implement `Cashier\Contracts\ProvidesInvoiceInformation` interface. For example:
+    - Implement `Laravel\Cashier\Order\Contracts\ProvidesInvoiceInformation` interface. For example:
     
     ```php
    /**


### PR DESCRIPTION
During the set up of the package I noticed that the namespace of the `ProvidesInvoiceInformation` contract has been changed. I updated the README accordingly.