### PR TITLE
Provide fallback for deprecated string helpers in Laravel 6

### DIFF
--- a/src/Helpers/helpers.php
+++ b/src/Helpers/helpers.php
@@ -94,3 +94,43 @@ if (! function_exists('mollie_object_to_money')) {
         return decimal_to_money($object->value, $object->currency);
     }
 }
+
+if (! function_exists('starts_with')) {
+    /**
+     * Determine if a given string starts with a given substring.
+     *
+     * @param  string  $haystack
+     * @param  string|array  $needles
+     * @return bool
+     */
+    function starts_with($haystack, $needles)
+    {
+        foreach ((array) $needles as $needle) {
+            if ($needle !== '' && substr($haystack, 0, strlen($needle)) === (string) $needle) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}
+
+if (! function_exists('ends_with')) {
+    /**
+     * Determine if a given string ends with a given substring.
+     *
+     * @param  string  $haystack
+     * @param  string|array  $needles
+     * @return bool
+     */
+    function ends_with($haystack, $needles)
+    {
+        foreach ((array) $needles as $needle) {
+            if (substr($haystack, -strlen($needle)) === (string) $needle) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}


### PR DESCRIPTION
While running the tests with Laravel 6.0, I noticed the string helper functions being used in the `OrderNumberGeneratorTest` class are throwing errors since they don't exist anymore in Laravel 6. (The string helpers functions have been replaced by the `Illuminate\Support\Str` helper)

 This pull request provides these functions back in when necessary.

We can't replace the functions with `Illuminate\Support\Str::startsWith` or `Illuminate\Support\Str::endsWith` (since the support for Laravel >=5.5 would drop).