### PR TITLE
Dispatch event after handling payment

### DIFF
--- a/src/Http/Controllers/FirstPaymentWebhookController.php
+++ b/src/Http/Controllers/FirstPaymentWebhookController.php
@@ -20,11 +20,11 @@ class FirstPaymentWebhookController extends BaseWebhookController
     {
         $payment = $this->getPaymentById($request->get('id'));
 
-        if($payment) {
+        if ($payment) {
             if ($payment->isPaid()) {
-                Event::dispatch(new FirstPaymentPaid($payment));
-
                 (new FirstPaymentHandler($payment))->execute();
+
+                Event::dispatch(new FirstPaymentPaid($payment));
             } elseif ($payment->isFailed()) {
                 Event::dispatch(new FirstPaymentFailed($payment));
             }


### PR DESCRIPTION
When you bind a listener to the event, the `mollie_payment_id` attribute of `Order` will still be `null` because the event is fired before the `FirstPaymentHandler` is executed. By swapping these two lines this should be fixed. The `OrderPaymentPaid` event is not fired when the first payment succeeds so that one can not be used.