### PR TITLE
Fix for Laravel's semantic versioning

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,8 +34,8 @@
         "ext-json": "*",
         "ext-intl": "*",
         "dompdf/dompdf": "^0.8.0",
-        "illuminate/database": "~5.8.0|~6.0.0",
-        "illuminate/support": "~5.8.0|~6.0.0",
+        "illuminate/database": "~5.8.0|^6.0",
+        "illuminate/support": "~5.8.0|^6.0",
         "mollie/laravel-mollie": "^2.5",
         "moneyphp/money": "^3.2",
         "nesbot/carbon": "^1.33 || ^2.0"


### PR DESCRIPTION
Laravel 6.1.0 and up were not supported due to the `~6.0.0` constraint.