### PR TITLE
Fixed redirect url not being loaded from plan

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,8 +34,8 @@
         "ext-json": "*",
         "ext-intl": "*",
         "dompdf/dompdf": "^0.8.0",
-        "illuminate/database": "~5.8.0|~6.0.0",
-        "illuminate/support": "~5.8.0|~6.0.0",
+        "illuminate/database": "~5.8.0|^6.0",
+        "illuminate/support": "~5.8.0|^6.0",
         "mollie/laravel-mollie": "^2.5",
         "moneyphp/money": "^3.2",
         "nesbot/carbon": "^1.33 || ^2.0"

--- a/src/FirstPayment/FirstPaymentBuilder.php
+++ b/src/FirstPayment/FirstPaymentBuilder.php
@@ -148,7 +148,8 @@ class FirstPaymentBuilder
      */
     public function setRedirectUrl(string $redirectUrl)
     {
-        $this->redirectUrl = url($redirectUrl);
+        if(!is_null($redirectUrl))
+            $this->redirectUrl = url($redirectUrl);
 
         return $this;
     }

--- a/src/SubscriptionBuilder/FirstPaymentSubscriptionBuilder.php
+++ b/src/SubscriptionBuilder/FirstPaymentSubscriptionBuilder.php
@@ -68,7 +68,7 @@ class FirstPaymentSubscriptionBuilder implements Contract
 
         $this->firstPaymentBuilder = new FirstPaymentBuilder($owner);
         $this->firstPaymentBuilder->setFirstPaymentMethod($this->plan->firstPaymentMethod());
-
+        $this->firstPaymentBuilder->setRedirectUrl($this->plan->firstPaymentRedirectUrl());
         $this->startSubscription = new StartSubscription($owner, $name, $plan);
     }
 


### PR DESCRIPTION
Based on my issue #88, I found that firstPaymentSubscriptionBuilder did not setRedirectUrl and only loaded the redirect URL from the config files. Added it to load from the plan. 