### PR TITLE
Release v1.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,23 @@ You can provide your own coupon handler by extending
 
 Out of the box, a basic `FixedDiscountHandler` is provided.
 
+#### Redeeming a coupon for an existing subscription
+
+For redeeming a coupon for an existing subscription, use the `redeemCoupon()` method on the billable trait:
+
+    $user->redeemCoupon('your-coupon-code');
+
+This will validate the coupon code and redeem it. The coupon will be applied to the upcoming Order.
+
+Optionally, specify the subscription it should be applied to:
+
+    $user->redeemCoupon('your-coupon-code', 'main');
+    
+By default all other active redeemed coupons for the subscription will be revoked. You can prevent this by setting the
+`$revokeOtherCoupons` flag to false:
+
+    $user->redeemCoupon('your-coupon-code', 'main', false);
+
 ### Checking subscription status
 
 Once a user is subscribed to your application, you may easily check their subscription status using a variety of convenient methods. First, the `subscribed` method returns `true` if the user has an active subscription, even if the subscription is currently within its trial period:

--- a/src/Billable.php
+++ b/src/Billable.php
@@ -398,7 +398,8 @@ trait Billable
             try {
                 return $customer->getMandate($id);
             } catch (ApiException $e) {
-                if (!in_array($e->getCode(), [404, 410])) {
+                // Status 410: mandate was revoked
+                if (! $e->getCode() == 410) {
                     throw $e;
                 }
             }

--- a/src/Billable.php
+++ b/src/Billable.php
@@ -4,11 +4,11 @@ namespace Laravel\Cashier;
 
 use Illuminate\Support\Facades\DB;
 use InvalidArgumentException;
-use Laravel\Cashier\Coupon\Contracts\AcceptsCoupons;
 use Laravel\Cashier\Coupon\Contracts\CouponRepository;
 use Laravel\Cashier\Coupon\RedeemedCoupon;
 use Laravel\Cashier\Credit\Credit;
 use Laravel\Cashier\Events\MandateClearedFromBillable;
+use Laravel\Cashier\Exceptions\InvalidMandateException;
 use Laravel\Cashier\Order\Order;
 use Laravel\Cashier\Order\OrderItem;
 use Laravel\Cashier\Plan\Contracts\PlanRepository;
@@ -100,22 +100,25 @@ trait Billable
     }
 
     /**
-     * Begin creating a new subscription for an already mandated customer.
+     * Begin creating a new subscription using an existing mandate.
      *
      * @param string $mandateId
      * @param  string $subscription
      * @param  string $plan
      * @return \Laravel\Cashier\SubscriptionBuilder\MandatedSubscriptionBuilder
      * @throws \Laravel\Cashier\Exceptions\PlanNotFoundException
-     * @throws \Throwable
+     * @throws \Throwable|\Laravel\Cashier\Exceptions\InvalidMandateException
      */
     public function newSubscriptionForMandateId($mandateId, $subscription, $plan)
     {
-        return new MandatedSubscriptionBuilder(
-            $this,
-            $subscription,
-            $plan
-        );
+        // The mandateId has changed
+        if($this->mollie_mandate_id !== $mandateId) {
+            $this->mollie_mandate_id = $mandateId;
+            $this->guardMollieMandate();
+            $this->save();
+        }
+
+        return new MandatedSubscriptionBuilder($this, $subscription, $plan);
     }
 
     /**
@@ -421,6 +424,17 @@ trait Billable
         $this->clearMollieMandate();
 
         return false;
+    }
+
+    /**
+     * @return bool
+     * @throws \Laravel\Cashier\Exceptions\InvalidMandateException
+     */
+    public function guardMollieMandate()
+    {
+        throw_unless($this->validateMollieMandate(), new InvalidMandateException);
+
+        return true;
     }
 
     /**

--- a/src/CashierServiceProvider.php
+++ b/src/CashierServiceProvider.php
@@ -14,7 +14,7 @@ use Mollie\Laravel\MollieServiceProvider;
 
 class CashierServiceProvider extends ServiceProvider
 {
-    const PACKAGE_VERSION = '1.4.0';
+    const PACKAGE_VERSION = '1.5.0';
 
     /**
      * Bootstrap the application services.

--- a/src/Exceptions/InvalidMandateException.php
+++ b/src/Exceptions/InvalidMandateException.php
@@ -14,7 +14,7 @@ class InvalidMandateException extends Exception
      * @param int $code
      * @param Throwable|null $previous
      */
-    public function __construct(string $message = 'Plan not found', int $code = 404, Throwable $previous = null)
+    public function __construct(string $message = 'Invalid customer mandate', int $code = 404, Throwable $previous = null)
     {
         parent::__construct($message, $code, $previous);
     }

--- a/src/Helpers/helpers.php
+++ b/src/Helpers/helpers.php
@@ -1,6 +1,7 @@
 <?php
 
 use Money\Currencies\ISOCurrencies;
+use Money\Currency;
 use Money\Formatter\DecimalMoneyFormatter;
 use Money\Money;
 use Money\Parser\DecimalMoneyParser;
@@ -92,5 +93,19 @@ if (! function_exists('mollie_object_to_money')) {
     function mollie_object_to_money(object $object)
     {
         return decimal_to_money($object->value, $object->currency);
+    }
+}
+
+if (! function_exists('money_to_decimal')) {
+
+    /**
+     * Format the money as basic decimal
+     *
+     * @param \Money\Money $money
+     * @return string|bool
+     */
+    function money_to_decimal(Money $money)
+    {
+        return (new DecimalMoneyFormatter(new ISOCurrencies()))->format($money);
     }
 }

--- a/src/Http/Controllers/WebhookController.php
+++ b/src/Http/Controllers/WebhookController.php
@@ -3,6 +3,7 @@
 namespace Laravel\Cashier\Http\Controllers;
 
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
 use Laravel\Cashier\Order\Order;
 use Mollie\Api\Types\PaymentStatus;
 use Symfony\Component\HttpFoundation\Response;
@@ -20,7 +21,7 @@ class WebhookController extends BaseWebhookController
 
         if($payment) {
             $order = Order::findByPaymentId($payment->id);
-            if ($order && $order->status !== $payment->status) {
+            if ($order && $order->mollie_payment_status !== $payment->status) {
                 switch ($payment->status) {
                     case PaymentStatus::STATUS_PAID:
                         $order->handlePaymentPaid();

--- a/src/Http/Controllers/WebhookController.php
+++ b/src/Http/Controllers/WebhookController.php
@@ -49,7 +49,7 @@ class WebhookController extends BaseWebhookController
 
         if(!$order) {
             if(isset($payment->metadata, $payment->metadata->temporary_mollie_payment_id)) {
-                $uuid = $payment->metadata->temporary_payment_id;
+                $uuid = 'temp_' . $payment->metadata->temporary_payment_id;
                 $order = Order::findByPaymentId($uuid);
             }
         }

--- a/src/Order/Order.php
+++ b/src/Order/Order.php
@@ -306,6 +306,18 @@ class Order extends Model
     }
 
     /**
+     * Retrieve an Order by the Mollie Payment id or throw an Exception if not found.
+     *
+     * @param $id
+     * @return self
+     * @throws \Illuminate\Database\Eloquent\ModelNotFoundException
+     */
+    public static function findByPaymentIdOrFail($id)
+    {
+        return self::whereMolliePaymentId($id)->firstOrFail();
+    }
+
+    /**
      * Checks whether credit was used in the Order.
      * The credit applied will be reset to 0 when an Order payment fails.
      *

--- a/src/Order/Order.php
+++ b/src/Order/Order.php
@@ -302,7 +302,7 @@ class Order extends Model
      */
     public static function findByPaymentId($id)
     {
-        return self::whereMolliePaymentId($id)->first();
+        return self::where('mollie_payment_id', $id)->first();
     }
 
     /**
@@ -314,7 +314,7 @@ class Order extends Model
      */
     public static function findByPaymentIdOrFail($id)
     {
-        return self::whereMolliePaymentId($id)->firstOrFail();
+        return self::where('mollie_payment_id', $id)->firstOrFail();
     }
 
     /**

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -630,12 +630,12 @@ class Subscription extends Model implements InteractsWithOrderItems, Preprocesse
     }
 
     /**
-     * Wraps up the current billing cycle, applies modifications to this subscription and starts a new cycle.
+     * Wrap up the current billing cycle, apply modifications to this subscription and start a new cycle.
      *
      * @param \Closure $applyNewSettings
      * @param \Carbon\Carbon|null $now
      * @param bool $invoiceNow
-     * @return mixed
+     * @return \Laravel\Cashier\Subscription
      */
     public function restartCycleWithModifications(\Closure $applyNewSettings, ?Carbon $now = null, $invoiceNow = true)
     {
@@ -676,6 +676,18 @@ class Subscription extends Model implements InteractsWithOrderItems, Preprocesse
 
             return $this;
         });
+    }
+
+    /**
+     * Wrap up the current billing cycle and start a new cycle.
+     *
+     * @param \Carbon\Carbon|null $now
+     * @param bool $invoiceNow
+     * @return \Laravel\Cashier\Subscription
+     */
+    public function restartCycle(?Carbon $now = null, $invoiceNow = true)
+    {
+        return $this->restartCycleWithModifications(function() {}, $now, $invoiceNow);
     }
 
     /**

--- a/src/SubscriptionBuilder/Contracts/SubscriptionBuilder.php
+++ b/src/SubscriptionBuilder/Contracts/SubscriptionBuilder.php
@@ -2,9 +2,7 @@
 
 namespace Laravel\Cashier\SubscriptionBuilder\Contracts;
 
-use Carbon\Carbon;
-
-interface SubscriptionBuilder
+interface SubscriptionBuilder extends SubscriptionConfigurator
 {
     /**
      * Create a new Cashier subscription. Returns a redirect to checkout if necessary.
@@ -13,43 +11,4 @@ interface SubscriptionBuilder
      */
     public function create();
 
-    /**
-     * Specify the number of days of the trial.
-     *
-     * @param  int $trialDays
-     * @return $this
-     */
-    public function trialDays(int $trialDays);
-
-    /**
-     * Specify the ending date of the trial.
-     *
-     * @param  Carbon $trialUntil
-     * @return $this
-     */
-    public function trialUntil(Carbon $trialUntil);
-
-    /**
-     * Override the default next payment date.
-     *
-     * @param \Carbon\Carbon $nextPaymentAt
-     * @return $this
-     */
-    public function nextPaymentAt(Carbon $nextPaymentAt);
-
-    /**
-     * Specify the quantity of the subscription.
-     *
-     * @param  int  $quantity
-     * @return $this
-     */
-    public function quantity(int $quantity);
-
-    /**
-     * Specify a discount coupon.
-     *
-     * @param string $coupon
-     * @return $this
-     */
-    public function withCoupon(string $coupon);
 }

--- a/src/SubscriptionBuilder/Contracts/SubscriptionConfigurator.php
+++ b/src/SubscriptionBuilder/Contracts/SubscriptionConfigurator.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Laravel\Cashier\SubscriptionBuilder\Contracts;
+
+use Carbon\Carbon;
+
+interface SubscriptionConfigurator
+{
+    /**
+     * Specify the number of days of the trial.
+     *
+     * @param  int $trialDays
+     * @return $this
+     */
+    public function trialDays(int $trialDays);
+
+    /**
+     * Specify the ending date of the trial.
+     *
+     * @param  Carbon $trialUntil
+     * @return $this
+     */
+    public function trialUntil(Carbon $trialUntil);
+
+    /**
+     * Force the trial to end immediately.
+     *
+     * @return $this
+     */
+    public function skipTrial();
+
+    /**
+     * Override the default next payment date.
+     *
+     * @param \Carbon\Carbon $nextPaymentAt
+     * @return $this
+     */
+    public function nextPaymentAt(Carbon $nextPaymentAt);
+
+    /**
+     * Specify the quantity of the subscription.
+     *
+     * @param  int  $quantity
+     * @return $this
+     */
+    public function quantity(int $quantity);
+
+    /**
+     * Specify a discount coupon.
+     *
+     * @param string $coupon
+     * @return $this
+     */
+    public function withCoupon(string $coupon);
+}

--- a/src/SubscriptionBuilder/FirstPaymentSubscriptionBuilder.php
+++ b/src/SubscriptionBuilder/FirstPaymentSubscriptionBuilder.php
@@ -139,6 +139,19 @@ class FirstPaymentSubscriptionBuilder implements Contract
     }
 
     /**
+     * Force the trial to end immediately.
+     *
+     * @return \Laravel\Cashier\SubscriptionBuilder\Contracts\SubscriptionBuilder|void
+     */
+    public function skipTrial()
+    {
+        $this->isTrial = false;
+        $this->startSubscription->skipTrial();
+
+        return $this;
+    }
+
+    /**
      * Specify the quantity of the subscription.
      *
      * @param  int $quantity

--- a/src/SubscriptionBuilder/MandatedSubscriptionBuilder.php
+++ b/src/SubscriptionBuilder/MandatedSubscriptionBuilder.php
@@ -162,6 +162,19 @@ class MandatedSubscriptionBuilder implements Contract
     }
 
     /**
+     * Force the trial to end immediately.
+     *
+     * @return \Laravel\Cashier\SubscriptionBuilder\Contracts\SubscriptionBuilder|void
+     */
+    public function skipTrial()
+    {
+        $this->trialExpires = null;
+        $this->nextPaymentAt = now();
+
+        return $this;
+    }
+
+    /**
      * Specify the quantity of the subscription.
      *
      * @param  int  $quantity

--- a/src/SubscriptionBuilder/MandatedSubscriptionBuilder.php
+++ b/src/SubscriptionBuilder/MandatedSubscriptionBuilder.php
@@ -87,9 +87,11 @@ class MandatedSubscriptionBuilder implements Contract
      *
      * @return Subscription
      * \Laravel\Cashier\Exceptions\CouponException
+     * @throws \Laravel\Cashier\Exceptions\InvalidMandateException
      */
     public function create()
     {
+        $this->owner->guardMollieMandate();
         $now = now();
 
         return DB::transaction(function () use ($now) {
@@ -108,7 +110,7 @@ class MandatedSubscriptionBuilder implements Contract
 
             $subscription->scheduleNewOrderItemAt($this->nextPaymentAt);
             $subscription->save();
-            
+
             $this->owner->cancelGenericTrial();
 
             return $subscription;

--- a/tests/FirstPayment/Actions/StartSubscriptionTest.php
+++ b/tests/FirstPayment/Actions/StartSubscriptionTest.php
@@ -103,6 +103,34 @@ class StartSubscriptionTest extends BaseTestCase
     }
 
     /** @test */
+    public function canGetPayloadWithSkipTrial()
+    {
+        $action = new StartSubscription(
+            $this->getMandatedUser(true, ['tax_percentage' => 20]),
+            'default',
+            'monthly-10-1'
+        );
+
+        $action->trialUntil(now()->addDays(5))->skipTrial();
+
+        $payload = $action->getPayload();
+
+        $this->assertEquals([
+            'handler' => StartSubscription::class,
+            'description' => 'Monthly payment',
+            'subtotal' => [
+                'value' => '10.00',
+                'currency' => 'EUR',
+            ],
+            'taxPercentage' => 20,
+            'plan' => 'monthly-10-1',
+            'name' => 'default',
+            'quantity' => 1,
+            'skipTrial' => true,
+        ], $payload);
+    }
+
+    /** @test */
     public function canGetPayloadWithCoupon()
     {
         $this->withMockedCouponRepository();
@@ -157,6 +185,18 @@ class StartSubscriptionTest extends BaseTestCase
             'trialDays' => 5,
             'subtotal' => [
                 'value' => '0.00',
+                'currency' => 'EUR',
+            ],
+        ]);
+    }
+
+    /** @test */
+    public function canCreateFromPayloadWithSkipTrial()
+    {
+        $this->assertFromPayloadToPayload([
+            'skipTrial' => true,
+            'subtotal' => [
+                'value' => '10.00',
                 'currency' => 'EUR',
             ],
         ]);

--- a/tests/Order/OrderTest.php
+++ b/tests/Order/OrderTest.php
@@ -424,6 +424,8 @@ class OrderTest extends BaseTestCase
     /** @test */
     public function findByPaymentIdWorks()
     {
+        $this->assertNull(Order::findByPaymentId('tr_xxxxx1234dummy'));
+
         $order = factory(Order::class)->create(['mollie_payment_id' => 'tr_xxxxx1234dummy']);
         $otherOrder = factory(Order::class)->create(['mollie_payment_id' => 'tr_wrong_order']);
 

--- a/tests/Order/OrderTest.php
+++ b/tests/Order/OrderTest.php
@@ -421,6 +421,18 @@ class OrderTest extends BaseTestCase
         $this->assertDispatchedOrderProcessed($order);
     }
 
+    /** @test */
+    public function findByPaymentIdWorks()
+    {
+        $order = factory(Order::class)->create(['mollie_payment_id' => 'tr_xxxxx1234dummy']);
+        $otherOrder = factory(Order::class)->create(['mollie_payment_id' => 'tr_wrong_order']);
+
+        $found = Order::findByPaymentId('tr_xxxxx1234dummy');
+
+        $this->assertTrue($found->is($order));
+        $this->assertTrue($found->isNot($otherOrder));
+    }
+
     /**
      * @test
      * @group generate_new_invoice_template

--- a/tests/Order/OrderTest.php
+++ b/tests/Order/OrderTest.php
@@ -435,6 +435,25 @@ class OrderTest extends BaseTestCase
         $this->assertTrue($found->isNot($otherOrder));
     }
 
+    /** @test */
+    public function findByPaymentIdOrFailThrowsAnExceptionIfNotFound()
+    {
+        $this->expectException(\Illuminate\Database\Eloquent\ModelNotFoundException::class);
+        Order::findByPaymentIdOrFail('tr_xxxxx1234dummy');
+    }
+
+    /** @test */
+    public function findByPaymentIdOrFailWorks()
+    {
+        $order = factory(Order::class)->create(['mollie_payment_id' => 'tr_xxxxx1234dummy']);
+        $otherOrder = factory(Order::class)->create(['mollie_payment_id' => 'tr_wrong_order']);
+
+        $found = Order::findByPaymentId('tr_xxxxx1234dummy');
+
+        $this->assertTrue($found->is($order));
+        $this->assertTrue($found->isNot($otherOrder));
+    }
+
     /**
      * @test
      * @group generate_new_invoice_template

--- a/tests/Order/OrderTest.php
+++ b/tests/Order/OrderTest.php
@@ -448,7 +448,7 @@ class OrderTest extends BaseTestCase
         $order = factory(Order::class)->create(['mollie_payment_id' => 'tr_xxxxx1234dummy']);
         $otherOrder = factory(Order::class)->create(['mollie_payment_id' => 'tr_wrong_order']);
 
-        $found = Order::findByPaymentId('tr_xxxxx1234dummy');
+        $found = Order::findByPaymentIdOrFail('tr_xxxxx1234dummy');
 
         $this->assertTrue($found->is($order));
         $this->assertTrue($found->isNot($otherOrder));

--- a/tests/SubscriptionBuilder/FirstPaymentSubscriptionBuilderTest.php
+++ b/tests/SubscriptionBuilder/FirstPaymentSubscriptionBuilderTest.php
@@ -187,6 +187,25 @@ class FirstPaymentSubscriptionBuilderTest extends BaseTestCase
         $this->assertEquals('EUR', $amount['currency']);
     }
 
+    /** @test */
+    public function testSkipTrialRevertsTheTrialAmount()
+    {
+        $trialBuilder = $this->getBuilder();
+
+        $trialBuilder->trialDays(5)->create();
+        $this->assertEquals(
+            '0.05',
+            $trialBuilder->getMandatePaymentBuilder()->getMolliePayload()['amount']['value']
+        );
+
+        $skipTrialBuilder = $this->getBuilder()->trialDays(5)->skipTrial();
+        $skipTrialBuilder->create();
+        $this->assertEquals(
+            '12.00',
+            $skipTrialBuilder->getMandatePaymentBuilder()->getMolliePayload()['amount']['value']
+        );
+    }
+
     /**
      * @return \Laravel\Cashier\SubscriptionBuilder\FirstPaymentSubscriptionBuilder
      */

--- a/tests/SubscriptionBuilder/MandatedSubscriptionBuilderTest.php
+++ b/tests/SubscriptionBuilder/MandatedSubscriptionBuilderTest.php
@@ -83,6 +83,17 @@ class MandatedSubscriptionBuilderTest extends BaseTestCase
         $this->getBuilder()->withCoupon('test-coupon')->create();
     }
 
+    /** @test */
+    public function testSkipTrialWorks()
+    {
+        $builder = $this->getBuilder()->trialDays(5);
+        $this->assertTrue($builder->makeSubscription()->onTrial());
+
+        $builder->skipTrial();
+        $this->assertFalse($builder->makeSubscription()->onTrial());
+    }
+
+
     /**
      * @return \Laravel\Cashier\SubscriptionBuilder\MandatedSubscriptionBuilder
      */

--- a/tests/SubscriptionBuilder/MandatedSubscriptionBuilderTest.php
+++ b/tests/SubscriptionBuilder/MandatedSubscriptionBuilderTest.php
@@ -18,7 +18,7 @@ class MandatedSubscriptionBuilderTest extends BaseTestCase
         parent::setUp();
         $this->withPackageMigrations();
         $this->withConfiguredPlans();
-        $this->user = $this->getCustomerUser(true);
+        $this->user = $this->getMandatedUser(true);
     }
 
     /** @test */


### PR DESCRIPTION
- Added `skipTrial` to the subscription builders (fixes #101)
- Improved mandate retrieval, validation and guard (fixes #105)
- Added `$billable->guardMollieMandate();`
- Added `$subscription->restartCycle();`
- Added `Order:: findByPaymentIdOrFail($paymentId);`
- Added payment status scopes to the Order model
- Added a `money_to_decimal()` helper function
- Fixed a race condition on mandated payments processing (fixes #100)
- Prepared release v1.5.0