### PR TITLE
Document loading coupons/plans from other sources than the config

### DIFF
--- a/README.md
+++ b/README.md
@@ -650,7 +650,7 @@ class DatabasePlanRepository implements PlanRepository
         }
 
         // Return a \Laravel\Cashier\Plan\Plan by creating one from the database values
-        return $plan->populateCashierPlan();
+        return $plan->buildCashierPlan();
 
         // Or if your model implements the contract: \Laravel\Cashier\Plan\Contracts\Plan
         return $plan;

--- a/README.md
+++ b/README.md
@@ -627,7 +627,7 @@ to update the subscription plan. A common use case for this is downgrading the p
 ### How can I load coupons and/or plans from database?
 
 Because Cashier Mollie uses contracts a lot it's quite easy to extend Cashier Mollie and use your own implementations.
-You can quite easily load coupons/plans from database, a file or even a JSON API.
+You can load coupons/plans from database, a file or even a JSON API.
 
 For example a simple implementation of plans from the database:
 

--- a/README.md
+++ b/README.md
@@ -668,18 +668,18 @@ class DatabasePlanRepository implements PlanRepository
 ```
 
 <details>
-  <summary>Example Plan model (app/Plan.php) with buildCashierPlan and returns a \Laravel\Cashier\Plan\Plan</summary>
+<summary>Example Plan model (app/Plan.php) with buildCashierPlan and returns a \Laravel\Cashier\Plan\Plan</summary>
 
-  ```php
-  <?php
+```php
+<?php
 
-  namespace App;
+namespace App;
 
-  use Laravel\Cashier\Plan\Plan as CashierPlan;
-  use Illuminate\Database\Eloquent\Model;
+use Laravel\Cashier\Plan\Plan as CashierPlan;
+use Illuminate\Database\Eloquent\Model;
 
-  class Plan extends Model
-  {
+class Plan extends Model
+{
     /**
      * Builds a Cashier plan from the current model.
      *
@@ -687,23 +687,23 @@ class DatabasePlanRepository implements PlanRepository
      */
     public function buildCashierPlan(): CashierPlan
     {
-      $plan = new CashierPlan($this->name);
-
-      return $plan->setAmount(mollie_array_to_money($this->amount))
-        ->setInterval($this->interval)
-        ->setDescription($this->description)
-        ->setFirstPaymentMethod($this->first_payment_method)
-        ->setFirstPaymentAmount(mollie_array_to_money($this->first_payment_amount))
-        ->setFirstPaymentDescription($this->first_payment_description)
-        ->setFirstPaymentRedirectUrl($this->first_payment_redirect_url)
-        ->setFirstPaymentWebhookUrl($this->first_payment_webhook_url)
-        ->setOrderItemPreprocessors(Preprocessors::fromArray($this->order_item_preprocessors));
+        $plan = new CashierPlan($this->name);
+        
+        return $plan->setAmount(mollie_array_to_money($this->amount))
+            ->setInterval($this->interval)
+            ->setDescription($this->description)
+            ->setFirstPaymentMethod($this->first_payment_method)
+            ->setFirstPaymentAmount(mollie_array_to_money($this->first_payment_amount))
+            ->setFirstPaymentDescription($this->first_payment_description)
+            ->setFirstPaymentRedirectUrl($this->first_payment_redirect_url)
+            ->setFirstPaymentWebhookUrl($this->first_payment_webhook_url)
+            ->setOrderItemPreprocessors(Preprocessors::fromArray($this->order_item_preprocessors));
     }
-  }
-  ```
+}
+```
 
-  Note: In this case you'll need to add accessors for all the values (like amount, interval, fist_payment_method etc.)
-  to make sure you'll use the values from your defaults (config/cashier_plans.php > defaults).
+Note: In this case you'll need to add accessors for all the values (like amount, interval, fist_payment_method etc.)
+to make sure you'll use the values from your defaults (config/cashier_plans.php > defaults).
 </details>
 
 Then you just have to bind your implementation to the Laravel/Illuminate container by registering the binding in a service provider

--- a/README.md
+++ b/README.md
@@ -667,6 +667,45 @@ class DatabasePlanRepository implements PlanRepository
 }
 ```
 
+<details>
+    <summary>Example Plan model (app/Plan.php) with buildCashierPlan and returns a `\Laravel\Cashier\Plan\Plan`</summary>
+    
+    ```php
+    <?php
+    
+    namespace App;
+    
+    use Laravel\Cashier\Plan\Plan as CashierPlan;
+    use Illuminate\Database\Eloquent\Model;
+    
+    class Plan extends Model
+    {
+        /**
+         * Builds a Cashier plan from the current model.
+         *
+         * @returns \Laravel\Cashier\Plan\Plan
+         */
+        public function buildCashierPlan(): CashierPlan
+        {
+            $plan = new CashierPlan($this->name);
+            
+            return $plan->setAmount(mollie_array_to_money($this->amount))
+                ->setInterval($this->interval)
+                ->setDescription($this->description)
+                ->setFirstPaymentMethod($this->first_payment_method)
+                ->setFirstPaymentAmount(mollie_array_to_money($this->first_payment_amount))
+                ->setFirstPaymentDescription($this->first_payment_description)
+                ->setFirstPaymentRedirectUrl($this->first_payment_redirect_url)
+                ->setFirstPaymentWebhookUrl($this->first_payment_webhook_url)
+                ->setOrderItemPreprocessors(Preprocessors::fromArray($this->order_item_preprocessors));
+        }
+    }
+    ```
+    
+    Nnote: In this case you'll need to add accessors for all the values (like amount, interval, fist_payment_method etc.)
+    to make sure you'll use the values from your defaults (config/cashier_plans.php > defaults).
+</details>
+
 Then you just have to bind your implementation to the Laravel/Illuminate container by registering the binding in a service provider
 
 ```php

--- a/README.md
+++ b/README.md
@@ -668,42 +668,42 @@ class DatabasePlanRepository implements PlanRepository
 ```
 
 <details>
-    <summary>Example Plan model (app/Plan.php) with buildCashierPlan and returns a `\Laravel\Cashier\Plan\Plan`</summary>
-    
-    ```php
-    <?php
-    
-    namespace App;
-    
-    use Laravel\Cashier\Plan\Plan as CashierPlan;
-    use Illuminate\Database\Eloquent\Model;
-    
-    class Plan extends Model
+  <summary>Example Plan model (app/Plan.php) with buildCashierPlan and returns a \Laravel\Cashier\Plan\Plan</summary>
+
+  ```php
+  <?php
+
+  namespace App;
+
+  use Laravel\Cashier\Plan\Plan as CashierPlan;
+  use Illuminate\Database\Eloquent\Model;
+
+  class Plan extends Model
+  {
+    /**
+     * Builds a Cashier plan from the current model.
+     *
+     * @returns \Laravel\Cashier\Plan\Plan
+     */
+    public function buildCashierPlan(): CashierPlan
     {
-        /**
-         * Builds a Cashier plan from the current model.
-         *
-         * @returns \Laravel\Cashier\Plan\Plan
-         */
-        public function buildCashierPlan(): CashierPlan
-        {
-            $plan = new CashierPlan($this->name);
-            
-            return $plan->setAmount(mollie_array_to_money($this->amount))
-                ->setInterval($this->interval)
-                ->setDescription($this->description)
-                ->setFirstPaymentMethod($this->first_payment_method)
-                ->setFirstPaymentAmount(mollie_array_to_money($this->first_payment_amount))
-                ->setFirstPaymentDescription($this->first_payment_description)
-                ->setFirstPaymentRedirectUrl($this->first_payment_redirect_url)
-                ->setFirstPaymentWebhookUrl($this->first_payment_webhook_url)
-                ->setOrderItemPreprocessors(Preprocessors::fromArray($this->order_item_preprocessors));
-        }
+      $plan = new CashierPlan($this->name);
+
+      return $plan->setAmount(mollie_array_to_money($this->amount))
+        ->setInterval($this->interval)
+        ->setDescription($this->description)
+        ->setFirstPaymentMethod($this->first_payment_method)
+        ->setFirstPaymentAmount(mollie_array_to_money($this->first_payment_amount))
+        ->setFirstPaymentDescription($this->first_payment_description)
+        ->setFirstPaymentRedirectUrl($this->first_payment_redirect_url)
+        ->setFirstPaymentWebhookUrl($this->first_payment_webhook_url)
+        ->setOrderItemPreprocessors(Preprocessors::fromArray($this->order_item_preprocessors));
     }
-    ```
-    
-    Nnote: In this case you'll need to add accessors for all the values (like amount, interval, fist_payment_method etc.)
-    to make sure you'll use the values from your defaults (config/cashier_plans.php > defaults).
+  }
+  ```
+
+  Note: In this case you'll need to add accessors for all the values (like amount, interval, fist_payment_method etc.)
+  to make sure you'll use the values from your defaults (config/cashier_plans.php > defaults).
 </details>
 
 Then you just have to bind your implementation to the Laravel/Illuminate container by registering the binding in a service provider


### PR DESCRIPTION
There have been a few issues about loading coupons/plans from other sources, mainly from the database. Since it's really easy to implement this by binding the contracts to your own implementation I thought it would be good to add a FAQ item for this.

Loading plans/coupons from the database makes the most sense to me, so I made a small example how to do this. I tried to keep it as short as possible, but still easy to understand.

Closes #133.