### PR TITLE
Add Dompdf Options as parameter

### DIFF
--- a/src/Order/Invoice.php
+++ b/src/Order/Invoice.php
@@ -4,6 +4,7 @@ namespace Laravel\Cashier\Order;
 
 use Carbon\Carbon;
 use Dompdf\Dompdf;
+use Dompdf\Options;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\View;
 use Illuminate\Support\Str;
@@ -447,15 +448,16 @@ class Invoice
      *
      * @param array $data
      * @param string $view
+     * @param \Dompdf\Options $options
      * @return string
      */
-    public function pdf(array $data = [], string $view = self::DEFAULT_VIEW)
+    public function pdf(array $data = [], string $view = self::DEFAULT_VIEW, Options $options = null)
     {
         if (! defined('DOMPDF_ENABLE_AUTOLOAD')) {
             define('DOMPDF_ENABLE_AUTOLOAD', false);
         }
 
-        $dompdf = new Dompdf;
+        $dompdf = new Dompdf($options);
         $dompdf->loadHtml($this->view($data, $view)->render());
         $dompdf->render();
 
@@ -467,16 +469,17 @@ class Invoice
      *
      * @param null|array $data
      * @param string $view
+     * @param \Dompdf\Options $options
      * @return \Symfony\Component\HttpFoundation\Response
      */
-    public function download(array $data = [], string $view = self::DEFAULT_VIEW)
+    public function download(array $data = [], string $view = self::DEFAULT_VIEW, Options $options = null)
     {
         $filename = implode('_', [
                 $this->id,
                 Str::snake(config('app.name', '')),
             ]) . '.pdf';
 
-        return new Response($this->pdf($data, $view), 200, [
+        return new Response($this->pdf($data, $view, $options), 200, [
             'Content-Description' => 'File Transfer',
             'Content-Disposition' => 'attachment; filename="'.$filename.'"',
             'Content-Transfer-Encoding' => 'binary',


### PR DESCRIPTION
I know this might not be directly related to mollie but in my case I had to change the paper size and font in order to support the cyrillic alphabet.

I didn't find any other way to do it so by adding a third optional parameter to _pdf()_ and _download()_ functions you can pass whatever options you need to the dompdf instance.

Example: 
``` php
$options= new Options();
$options->set('defaultPaperSize', 'A4');
$options->set('defaultPaperOrientation', 'landscape');
$options->set('isRemoteEnabled', TRUE); //Allows the use of images in the invoice
$options->set('defaultFont', 'dejavu serif');
return $invoice->download([], 'cashier::receipt', $options);
```
All available options can be found here: [Dompdf\Options](https://github.com/dompdf/dompdf/blob/master/src/Options.php)