### PR TITLE
Refuse to use credits when Invoice total is negative

### DIFF
--- a/src/Order/Order.php
+++ b/src/Order/Order.php
@@ -153,7 +153,7 @@ class Order extends Model
             $owner = $this->owner;
 
             // Process user balance, if any
-            if($owner->hasCredit($this->currency)) {
+            if($this->getTotal()->getAmount() > 0 && $owner->hasCredit($this->currency)) {
                 $total = $this->getTotal();
                 $this->balance_before = $owner->credit($this->currency)->value;
 


### PR DESCRIPTION
When an invoice total was negative. Cashier was trying to pay for it with available credits. This caused wrong invoices.