### PR TITLE
Fix deprecation warning in helper function

### DIFF
--- a/src/Helpers/helpers.php
+++ b/src/Helpers/helpers.php
@@ -32,7 +32,7 @@ if (! function_exists('money')) {
      */
     function money(int $value, string $currency)
     {
-        return new Money($value, new \Money\Currency($currency));
+        return new Money($value, new Currency($currency));
     }
 }
 
@@ -48,7 +48,7 @@ if (! function_exists('decimal_to_money')) {
     {
         $moneyParser = new DecimalMoneyParser(new ISOCurrencies());
 
-        return $moneyParser->parse($value, $currency);
+        return $moneyParser->parse($value, new Currency($currency));
     }
 }
 


### PR DESCRIPTION
This fixes the deprecation warning raised by moneyphp. In the next release of [moneyphp](https://github.com/moneyphp/money/blob/master/src/Parser/DecimalMoneyParser.php#L49-L57), passing the currency to the money parser as a string will result in an error.