### PR TITLE
Add possibility to add actions to first payment subscription builder

### DIFF
--- a/src/SubscriptionBuilder/FirstPaymentSubscriptionBuilder.php
+++ b/src/SubscriptionBuilder/FirstPaymentSubscriptionBuilder.php
@@ -216,7 +216,12 @@ class FirstPaymentSubscriptionBuilder implements Contract
         return $this->firstPaymentBuilder;
     }
 
-    public function addAction(BaseAction $action, $prepend = false)
+    /**
+     * @param BaseAction $action
+     * @param bool $prepend
+     * @return $this
+     */
+    public function addAction(BaseAction $action, bool $prepend = false)
     {
         if ($prepend) {
             $this->actions->prepend($action);


### PR DESCRIPTION
This adds the functionality to add additional actions to the `FirstPaymentSubscriptionBuilder` class.

This way I can add a discount to the actions and display the order item on the first invoice.

This is how the first payment payload looks like:

```json
{
  "owner": {
    "type": "Laravel\\Cashier\\Tests\\Fixtures\\User",
    "id": 1
  },
  "actions": [
    {
      "handler": "Laravel\\Cashier\\FirstPayment\\Actions\\StartSubscription",
      "description": "Monthly payment",
      "subtotal": {
        "currency": "EUR",
        "value": "10.00"
      },
      "taxPercentage": 20,
      "plan": "monthly-10-1",
      "name": "default",
      "quantity": 1
    },
    {
      "handler": "Laravel\\Cashier\\FirstPayment\\Actions\\AddGenericOrderItem",
      "description": "First Payment Custom Discount",
      "subtotal": {
        "currency": "EUR",
        "value": "-5.50"
      },
      "taxPercentage": 20
    }
  ]
}
```