### PR TITLE
WIP - One off charges

### DIFF
--- a/README.md
+++ b/README.md
@@ -447,7 +447,188 @@ Additionally, listen for the following events (in the `Laravel\Cashier\Events` n
 
 ### One-off charges
 
-Coming soon.
+Sometimes you may want to have your customers pay for a one-time fee.
+An example of this could be a lifetime license for you product.
+In this scenario you simply wish to charge your customers once, and not set up a [mandate](https://docs.mollie.com/payments/recurring) (which authorizes you to charge the client multiple times).
+However, if the customer already has a valid mandate (because they are already on a subscription for example) we will use the mandate to charge the customer directly.
+This means that the customer does not have to go through the payment screen again, which is user friendly.
+
+As you may have noticed already, the payment flow described above is quite similar to the payment flow of setting up a subscription.
+
+#### Adding an item to the tab
+If you wish to add something to the next upcoming order (or invoice for that matter),
+you can use the `tab` method on the model that is using the `Billable` trait.
+ 
+From here on we take the `$user` as our `Billable` model.
+
+> **Important note:**
+> 
+> You can put items on the tab without having a valid mandate for the user.
+> - When creating the invoice we will create a `RedirectToCheckoutResponse` if your customer doesn't have a valid mandate.
+> - When the user you are creating an order for already has a valid mandate, we will directly create the order.
+
+The basic usage is as follows:
+
+```php
+// Here 1000 is the amount in the smallest denomination for your default currency.
+$orderItem = $user->tab('A description of the order item', 1000);
+```
+
+If you wish to override any specific fields on the order item you can pass them as the third parameters:
+
+```php
+$orderItem = $user->tab('A potato, not very premium', 100, [
+    'currency' => 'USD', // a non-default currency
+    'description_extra_lines' => [
+        'This potato was almost rotten... but still delicious.',
+    ],
+]);
+```
+
+The order items that you put on the tab can be manually invoiced [using the `invoice` method](#invoicing-items-on-the-tab).
+If you only wish to put one item on the tab and invoice it immediately [have a look at `invoiceFor`](#putting-one-item-on-the-tab-and-invoicing-it-immediately).
+
+> **Important note:** 
+> 
+> Since `php artisan cashier:run` is usually scheduled to run daily, items you put on the tab (but don't immediately invoice) will be invoiced automatically.
+> If this is not what you want, [change the time the order item on the tab is processed.](changing-when-the-items-on-the-tab-should-be-invoiced) 
+
+#### Changing when the items on the tab should be invoiced.
+Since usually you have set `php artisan cashier:run` to run daily in your `App\Console\Kernel@schedule` method, the order items you put on the tab will be invoiced today/tomorrow.
+If this is not what you want, override the `process_at` property.
+
+```php
+// On the first day of the month
+$user->tab('Lifetime license for Product A', 35000, [
+    'process_at' => now()->endOfMonth()->startOfDay(),
+]);
+
+// On the second day of the month
+$user->tab('Lifetime license for Product B', 35000, [
+    'process_at' => now()->endOfMonth()->startOfDay(),
+]);
+```
+
+Cashier will automatically group the open tab (order items) in one order when it runs at the last day of the month.
+
+You now have the possibility to put multiple items on the tab, and invoice them together at a later point in time!
+
+```php
+$result = $user->invoiceFor('Something', 1000, [
+    // Optional. Is the default, will be used if there is no mandate, handles payment webhook.
+    'webhookUrl' => config('cashier.one_off_payment.webhook_url'),
+
+    // Optional. Is the default, will be used by Mollie if there is no mandate, after the user has paid.
+    'redirectUrl' => config('cashier.one_off_payment.redirect_url'), 
+
+    // Optional. Default => null or empty array, which let's Mollie decide.
+    'method' => config('cashier.one_off_payment.active_payment_methods'),
+
+    // Optional. @see Cashier::getLocale()
+    'locale' => Cashier::getLocale($this),
+
+    // Optional. Description on the payment. Will be shown on the bank statement.
+    // Default => $items->pluck('description')->implode(', )
+    'description' => 'An alternative payment description than "Something"',
+]);
+```
+
+#### Invoicing items on the tab
+If you wish to try to invoice open items on the tab immediately, you can use the `invoice` method.
+Calling the invoice method will collect all open order items (the open tab) that are due for processing and puts them on an order.
+If you leave the currency unspecified it will try to invoice the default currency.
+
+##### Inspecting the current open tab
+
+To check what the order (+ invoice) would look like of you were to call the `invoice` method now, you can use the `upcomingInvoice` method.
+
+```php
+// Simple, default currency.
+$order = $user->upcomingInvoice();
+$invoice = $order->invoice('concept', now());
+
+// Other currency than default.
+$order = $user->upcomingInvoice(['currency' => 'USD']);
+```
+
+If you like what you see, you can call the `invoice` method.
+
+```php
+$result = $user->invoice();
+```
+
+##### Invoicing the items in default currency on the tab
+If you wish to invoice the items in the default currency simply call the `invoice` method.
+
+```php
+$result = $user->invoice(['description' => 'Something that will get on invoice & user bank records.']);
+
+if ($result === false) {
+    // There was no open tab due for processing in the currency you tried to invoice.
+} elseif (is_a($result, RedirectRedirectToCheckoutResponse::class)) {
+    // The user has an open tab, redirect to Mollie to let them pay for it.
+    // After the user successfully paid, we will create an Order for it.
+    return $result;
+} elseif (is_a($result, Order::class)) {
+    // The user had an open tab and a valid mandate.
+    // We used the mandate to invoice them, and create an Order (+ Invoice).
+}
+```
+
+##### Invoicing the items in a different currency than the default
+If you wish to invoice the items on the tab that are not in the default currency, you can pass the currency.
+The rest of the steps are the same as invoicing in the default currency.
+
+```php
+$invoice = $user->invoice(['currency' => 'USD']);
+```
+
+#### Putting one item on the tab and invoicing it immediately
+If you wish to put one item on the tab and invoice it immediately, you can use the `invoiceFor` method.
+This is basically a shortcut for using `tab` and `invoice` consecutively.
+
+If something like the following is your scenario:
+```php
+$orderItem = $user->tab('Premium item', 30000, [
+    'currency' => 'USD',
+    'description_extra_lines' => [
+        'Extra line',
+        'Another line'
+    ],
+]);
+
+$result = $user->invoice([
+    'currency' => 'USD',
+
+    // Note: the description will be visible on the invoice & customer bank records.
+    'description' => 'Lifetime license for my product',
+]);
+
+// Do the invoice handling like documented at the `invoice` method.
+```
+
+You may rewrite this as:
+
+```php
+$result = $user->invoiceFor(
+    'Premium item',
+    30000,
+    // Order item options (same as 3rd parameter of `tab`)
+    [
+        'currency' => 'USD',
+        'description_extra_lines' => [
+            'Extra line',
+            'Another line'
+        ],
+    ],
+    // Invoice options (same as 1st parameter of `invoice`)
+    [
+       'description' => 'Lifetime license for my product',
+    ]
+);
+
+// Do the invoice handling like documented at the `invoice` method.
+```
 
 ### Invoices
 
@@ -485,7 +666,28 @@ Route::middleware('auth')->get('/download-invoice/{orderId}', function($orderId)
 
     return (request()->user()->downloadInvoice($orderId));
 });
+```
 
+#### Finding a specific invoice
+
+##### findInvoice
+It's possible to find a specific invoice by it's order id.
+
+```php
+$user->findInvoice($orderId);
+```
+
+> If the invoice is not associated with the user you're searching for, it will throw an `UnauthorizedInvoiceAccessException`.
+
+##### findInvoiceOrFail
+If you wish to show a 404 error page whenever the invoice is not found, you may use the `findInvoiceOrFail` method on your user.
+If the invoice can not be found, a `\Symfony\Component\HttpKernel\Exception\NotFoundHttpException` will be thrown.
+If the invoice doesn't belong to the user, it will throw a `\Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException`. 
+In a standard Laravel application those exceptions will be turned in a proper 404 or respectively 403 HTTP response.
+
+```php
+$user->findInvoiceOrFail($orderId);
+```
 
 ### Refunding Charges
 

--- a/config/cashier.php
+++ b/config/cashier.php
@@ -83,4 +83,37 @@ return [
         'description' => 'Welcome to ' . config('app.name'),
     ],
 
+    /**
+     * A one off payment may require a customer to go through the Mollie checkout screen,
+     * but only if they don't have a valid mandate.
+     */
+    'one_off_payment' => [
+
+        /**
+         * The one off payment webhook url is called by Mollie on one off payment status updates.
+         * Can be overridden per invoice. You can use either a relative or absolute url.
+         * To override this webhook url on invoice level add the 'webhookUrl' option.
+         */
+        'webhook_url' => 'webhooks/mollie/one-off-payment',
+
+        /**
+         * The default url the customer is redirected to after the Mollie one off payment checkout screen. Can be
+         * overridden per invoice. You can use a `{payment_id}` placeholder here to easily retrieve the Mollie payment
+         * in your controller. Make sure you have set up a matching route.
+         */
+        'redirect_url' => config('app.url'),
+
+        /**
+         * If you wish to limit the payment methods your customers can use, you may
+         * fill the array with \Mollie\Api\Types\PaymentMethod you wish to allow.
+         * Leaving it as an empty array defaults to all payment methods.
+         * @see \Mollie\Api\Types\PaymentMethod
+         */
+        'active_payment_methods' => [],
+
+        /**
+         * The default description for a one off payment, visible on both the invoice and the customer bank records.
+         */
+        'description' => 'Welcome to ' . config('app.name'),
+    ]
 ];

--- a/routes/webhooks.php
+++ b/routes/webhooks.php
@@ -12,4 +12,9 @@ Route::namespace('\Laravel\Cashier\Http\Controllers')->group(function () {
         'FirstPaymentWebhookController@handleWebhook'
     );
 
+    Route::name('webhooks.mollie.one_off_payment')->post(
+        'webhooks/mollie/one-off-payment',
+        'OneOffPaymentWebhookController@handleWebhook'
+    );
+
 });

--- a/src/Billable.php
+++ b/src/Billable.php
@@ -9,12 +9,12 @@ use Laravel\Cashier\Coupon\RedeemedCoupon;
 use Laravel\Cashier\Credit\Credit;
 use Laravel\Cashier\Events\MandateClearedFromBillable;
 use Laravel\Cashier\Exceptions\InvalidMandateException;
-use Laravel\Cashier\Order\Invoice;
 use Laravel\Cashier\Order\Order;
 use Laravel\Cashier\Order\OrderItem;
 use Laravel\Cashier\Plan\Contracts\PlanRepository;
 use Laravel\Cashier\SubscriptionBuilder\FirstPaymentSubscriptionBuilder;
 use Laravel\Cashier\SubscriptionBuilder\MandatedSubscriptionBuilder;
+use Laravel\Cashier\Traits\ManagesInvoices;
 use Laravel\Cashier\Traits\PopulatesMollieCustomerFields;
 use Mollie\Api\Exceptions\ApiException;
 use Mollie\Api\Resources\Customer;
@@ -24,6 +24,7 @@ use Money\Money;
 trait Billable
 {
     use PopulatesMollieCustomerFields;
+    use ManagesInvoices;
 
     /**
      * Get all of the subscriptions for the billable model.
@@ -376,22 +377,6 @@ trait Billable
     public function invoices()
     {
         return $this->orders->invoices();
-    }
-
-    /**
-     * Create an invoice download response.
-     *
-     * @param $orderId
-     * @param null|array $data
-     * @param string $view
-     * @return \Symfony\Component\HttpFoundation\Response
-     */
-    public function downloadInvoice($orderId, $data = [], $view = Invoice::DEFAULT_VIEW)
-    {
-        /** @var Order $order */
-        $order = $this->orders()->where('id', $orderId)->firstOrFail();
-
-        return $order->invoice()->download($data, $view);
     }
 
     /**

--- a/src/Exceptions/UnauthorizedInvoiceAccessException.php
+++ b/src/Exceptions/UnauthorizedInvoiceAccessException.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Laravel\Cashier\Exceptions;
+
+use Exception;
+use Throwable;
+
+class UnauthorizedInvoiceAccessException extends Exception
+{
+    /**
+     * InvalidInvoiceAccessException constructor.
+     *
+     * @param string $message
+     * @param int $code
+     * @param \Throwable|null $previous
+     */
+    public function __construct(string $message = 'This user does not have access to this invoice.', int $code = 403, Throwable $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+    }
+}

--- a/src/Http/Controllers/OneOffPaymentWebhookController.php
+++ b/src/Http/Controllers/OneOffPaymentWebhookController.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Laravel\Cashier\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Event;
+use Laravel\Cashier\Events\OrderPaymentFailed;
+use Laravel\Cashier\Events\OrderPaymentPaid;
+use Laravel\Cashier\OneOffPayment\OneOffPaymentHandler;
+use Symfony\Component\HttpFoundation\Response;
+
+class OneOffPaymentWebhookController extends BaseWebhookController
+{
+    /**
+     * @param Request $request
+     * @return Response
+     * @throws \Mollie\Api\Exceptions\ApiException Only in debug mode
+     */
+    public function handleWebhook(Request $request)
+    {
+        $payment = $this->getPaymentById($request->get('id'));
+
+        if ($payment) {
+            if ($payment->isPaid()) {
+                $order = (new OneOffPaymentHandler($payment))->execute();
+
+                Event::dispatch(new OrderPaymentPaid($order));
+            } elseif ($payment->isFailed()) {
+                Event::dispatch(new OrderPaymentFailed($payment));
+            }
+        }
+
+        return new Response(null, 200);
+    }
+}

--- a/src/OneOffPayment/OneOffPaymentHandler.php
+++ b/src/OneOffPayment/OneOffPaymentHandler.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Laravel\Cashier\OneOffPayment;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Arr;
+use Laravel\Cashier\Order\Order;
+use Laravel\Cashier\Order\OrderItem;
+use Mollie\Api\Resources\Payment;
+
+final class OneOffPaymentHandler
+{
+    /** @var \Illuminate\Database\Eloquent\Model */
+    protected $owner;
+
+    /** @var \Mollie\Api\Resources\Payment */
+    protected $payment;
+
+    /** @var \Laravel\Cashier\Order\OrderItemCollection */
+    protected $items;
+
+    /**
+     * FirstPaymentHandler constructor.
+     *
+     * @param \Mollie\Api\Resources\Payment $payment
+     */
+    public function __construct(Payment $payment)
+    {
+        $this->payment = $payment;
+        $this->extractOwnerAndItems($payment);
+    }
+
+    /**
+     * @return void
+     */
+    private function extractOwnerAndItems(Payment $payment)
+    {
+        // Extract owner
+        $ownerType = $payment->metadata->owner->type;
+        $ownerID = $payment->metadata->owner->id;
+
+        $this->owner = Model::getActualClassNameForMorph($ownerType)::findOrFail($ownerID);
+
+        // Extract items from payment
+        $items = (array) $payment->metadata->items;
+        $orderIds = Arr::pluck($items, 'id');
+
+        $this->items = OrderItem::forOwner($this->owner)
+            ->whereIn('id', $orderIds)
+            ->get();
+    }
+
+    /**
+     * Execute all actions for the mandate payment and return the created Order.
+     *
+     * @return \Laravel\Cashier\Order\Order
+     */
+    public function execute()
+    {
+        return Order::createProcessedFromItems($this->items, [
+            'mollie_payment_id' => $this->payment->id,
+            'mollie_payment_status' => $this->payment->status,
+        ]);
+    }
+
+    /**
+     * Retrieve the owner object.
+     *
+     * @return \Illuminate\Database\Eloquent\Model
+     */
+    public function getOwner()
+    {
+        return $this->owner;
+    }
+
+    /**
+     * Retrieve all Action objects.
+     *
+     * @return \Laravel\Cashier\Order\OrderItemCollection
+     */
+    public function getItems()
+    {
+        return $this->items;
+    }
+}

--- a/src/Order/Order.php
+++ b/src/Order/Order.php
@@ -8,6 +8,7 @@ use Illuminate\Database\Query\Builder;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Str;
+use Laravel\Cashier\Cashier;
 use Laravel\Cashier\Credit\Credit;
 use Laravel\Cashier\Events\BalanceTurnedStale;
 use Laravel\Cashier\Events\OrderCreated;
@@ -62,38 +63,24 @@ class Order extends Model
     public static function createFromItems(OrderItemCollection $items, $overrides = [], $process_items = true)
     {
         return DB::transaction(function () use ($items, $overrides, $process_items) {
-            if($process_items) {
+            if ($process_items) {
                 $items = $items->preprocess();
             }
 
-            if($items->currencies()->count() > 1) {
-                throw new LogicException('Creating an order requires items to have a single currency.');
-            }
-
-            if($items->owners()->count() > 1) {
-                throw new LogicException('Creating an order requires items to have a single owner.');
-            }
-
-            $currency = $items->first()->currency;
-            $owner = $items->first()->owner;
-
-            $total = $items->sum('total');
-
-            $order = static::create(array_merge([
-                'owner_id' => $owner->id,
-                'owner_type' => get_class($owner),
-                'number' => static::numberGenerator()->generate(),
-                'currency' => $currency,
-                'subtotal' => $items->sum('subtotal'),
-                'tax' => $items->sum('tax'),
-                'total' => $total,
-                'total_due' => $total,
-            ], $overrides));
+            $order = self::make(
+                $items->first()->owner,
+                $items,
+                array_merge([
+                    'number' => static::numberGenerator()->generate(),
+                    'currency' => $items->first()->currency,
+                ], $overrides)
+            );
+            $order->save();
 
             $items->each(function (OrderItem $item) use ($order, $process_items) {
                 $item->update(['order_id' => $order->id]);
 
-                if($process_items) {
+                if ($process_items) {
                     $item->process();
                 }
             });
@@ -102,6 +89,44 @@ class Order extends Model
 
             return $order;
         });
+    }
+
+    /**
+     * Create a new concept Order for a specific Owner with Order Items.
+     *
+     * @param Model $owner
+     * @param OrderItemCollection $items
+     * @param array $overrides
+     * @return Order
+     */
+    public static function make(Model $owner, OrderItemCollection $items, array $overrides = [])
+    {
+        $currencies = $items->currencies();
+
+        // Check if the invoice + order item currencies match
+        if ($overrides['currency'] ?? false) {
+            $currencies->add($overrides['currency']);
+        }
+
+        if ($items->currencies()->count() > 1) {
+            throw new LogicException('Creating an order requires items to have a single currency.');
+        }
+
+        if ($items->owners()->count() > 1) {
+            throw new LogicException('Creating an order requires items to have a single owner.');
+        }
+
+        $order = new self(array_merge([
+            'owner_id' => $owner->getKey(),
+            'owner_type' => $owner->getMorphClass(),
+            'currency' => Cashier::usesCurrency(),
+            'subtotal' => $items->sum('subtotal'),
+            'tax' => $items->sum('tax'),
+            'total' => $total = $items->sum('total'),
+            'total_due' => $total,
+        ], $overrides));
+
+        return $order->setRelation('items', $items);
     }
 
     /**

--- a/src/Order/OrderItem.php
+++ b/src/Order/OrderItem.php
@@ -151,6 +151,31 @@ class OrderItem extends Model implements InvoicableItem
     }
 
     /**
+     * Limits the query to Order Items that belong to a specific owner.
+     *
+     * @param $query
+     * @param Model $owner
+     * @return mixed
+     */
+    public function scopeForOwner($query, Model $owner)
+    {
+        return $query->where('owner_type', $owner->getMorphClass())
+            ->where('owner_id', $owner->getKey());
+    }
+
+    /**
+     * Limits the query to Order Items of a specified currency.
+     *
+     * @param $query
+     * @param string $currency
+     * @return mixed
+     */
+    public function scopeOfCurrency($query, $currency)
+    {
+        return $query->where('currency', $currency);
+    }
+
+    /**
      * Create a new Eloquent Collection instance.
      *
      * @param  array  $models

--- a/src/Order/OrderItemCollection.php
+++ b/src/Order/OrderItemCollection.php
@@ -153,4 +153,20 @@ class OrderItemCollection extends Collection
     {
         return collect(array_values($this->pluck('tax_percentage')->unique()->sort()->all()));
     }
+
+    /**
+     * Return the total of the collection of items.
+     * @return \Money\Money
+     * @throws \LogicException
+     */
+    public function total()
+    {
+        if ($this->currencies()->count() > 1) {
+            throw new \LogicException('Calculating the total requires all items to have the same currency.');
+        }
+
+        return $this->reduce(function($sum, $item) {
+            return $sum->add($item->getTotal());
+        }, money(0, $this->first()->currency));
+    }
 }

--- a/src/Traits/ManagesInvoices.php
+++ b/src/Traits/ManagesInvoices.php
@@ -1,0 +1,214 @@
+<?php
+
+namespace Laravel\Cashier\Traits;
+
+use Illuminate\Support\Str;
+use Laravel\Cashier\Cashier;
+use Laravel\Cashier\Exceptions\UnauthorizedInvoiceAccessException;
+use Laravel\Cashier\OneOffPayment\OneOffPaymentBuilder;
+use Laravel\Cashier\Order\Invoice;
+use Laravel\Cashier\Order\Order;
+use Laravel\Cashier\Order\OrderItem;
+use Laravel\Cashier\Order\OrderItemCollection;
+use Laravel\Cashier\SubscriptionBuilder\RedirectToCheckoutResponse;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+trait ManagesInvoices
+{
+    /**
+     * Find an invoice by ID.
+     *
+     * @param string $orderId
+     * @return Invoice|null
+     * @throws \Laravel\Cashier\Exceptions\UnauthorizedInvoiceAccessException
+     */
+    public function findInvoice($orderId)
+    {
+        /** @var Order|null $order */
+        $order = Order::find($orderId);
+
+        if (is_null($order)) {
+            return null;
+        }
+
+        if ($order->owner->isNot($this)) {
+            throw new UnauthorizedInvoiceAccessException;
+        }
+
+        return $order->invoice();
+    }
+
+    /**
+     * Find an invoice or throw a 404 or 403 error.
+     *
+     * @param string $id
+     * @return \Laravel\Cashier\Order\Invoice
+     * @throws \Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException
+     * @throws \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
+     */
+    public function findInvoiceOrFail($id)
+    {
+        try {
+            $invoice = $this->findInvoice($id);
+        } catch (UnauthorizedInvoiceAccessException $exception) {
+            throw new AccessDeniedHttpException;
+        }
+
+        if (is_null($invoice)) {
+            throw new NotFoundHttpException;
+        }
+
+        return $invoice;
+    }
+
+    /**
+     * Create an invoice download response.
+     *
+     * @param $orderId
+     * @param null|array $data
+     * @param string $view
+     * @return \Symfony\Component\HttpFoundation\Response
+     * @throws \Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException
+     * @throws \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
+     */
+    public function downloadInvoice($orderId, $data = [], $view = Invoice::DEFAULT_VIEW)
+    {
+        return $this->findInvoiceOrFail($orderId)
+            ->download($data, $view);
+    }
+
+    /**
+     * Add an invoice item to the customer's upcoming invoice.
+     *
+     * @param string $description
+     * @param int $amount
+     * @param array $overrides
+     * @return OrderItem
+     */
+    public function tab($description, $amount, array $overrides = [])
+    {
+        $defaultOptions = [
+            'currency' => Cashier::usesCurrency(),
+            'unit_price' => $amount,
+            'tax_percentage' => $this->taxPercentage(),
+            'description' => $description,
+            'process_at' => now()->subMinute(), // Next time Cashier runs, or when using `invoice` method.
+        ];
+
+        $attributes = array_merge($defaultOptions, $overrides, [
+            'owner_type' => $this->getMorphClass(),
+            'owner_id' => $this->getKey(),
+            'order_id' => null,
+        ]);
+
+        $attributes['currency'] = Str::upper($attributes['currency']);
+
+        return OrderItem::create($attributes);
+    }
+
+    /**
+     * Invoice the customer for the given amount and generate an invoice immediately.
+     *
+     * @param string $description
+     * @param int $amount
+     * @param array $tabOptions
+     * @param array $paymentOptions
+     * @return \Laravel\Cashier\Order\Order|bool
+     */
+    public function invoiceFor($description, $amount, array $tabOptions = [], $paymentOptions = [])
+    {
+        // Normalize currency to capitalized
+        // Force the currency of the payment options the same as the tab options currency.
+        if ($tabOptions['currency'] ?? false) {
+            $tabOptions['currency'] = Str::upper($tabOptions['currency']);
+            $paymentOptions['currency'] = $tabOptions['currency'];
+        }
+
+        $this->tab($description, $amount, $tabOptions);
+
+        // Force the invoice method to use the same currency as the order item.
+        return $this->invoice($paymentOptions);
+    }
+
+    /**
+     * Invoice the billable entity outside of the regular billing cycle.
+     *
+     * @param array $paymentOptions
+     * @return \Laravel\Cashier\Order\Order|\Laravel\Cashier\SubscriptionBuilder\RedirectToCheckoutResponse|bool
+     */
+    public function invoice(array $paymentOptions = [])
+    {
+        // Normalize currency; set to default if it's missing, capitalize it.
+        if (!($paymentOptions['currency'] ?? false)) {
+            $paymentOptions['currency'] = Cashier::usesCurrency();
+        }
+        $paymentOptions['currency'] = Str::upper($paymentOptions['currency']);
+
+        // Check if there's something to invoice
+        $itemsToOrder = OrderItem::shouldProcess()
+            ->forOwner($this)
+            ->ofCurrency($paymentOptions['currency'])
+            ->get();
+
+        // No open order items for this user with the specified currency
+        if ($itemsToOrder->isEmpty()) {
+            return false;
+        }
+
+        if ($this->validateMollieMandate()) {
+            return Order::createFromItems($itemsToOrder, [
+                'currency' => $paymentOptions['currency']
+            ])->processPayment();
+        }
+
+        return $this->newOneOffPaymentViaCheckout($itemsToOrder, $paymentOptions);
+    }
+
+    /**
+     * Create a new RedirectToCheckoutResponse for a one off payment.
+     *
+     * @link https://docs.mollie.com/reference/v2/payments-api/create-payment#parameters
+     * @param OrderItemCollection $items
+     * @param array $oneOffPaymentOptions !Overrides the Mollie payment options
+     * @return RedirectToCheckoutResponse
+     */
+    protected function newOneOffPaymentViaCheckout(OrderItemCollection $items, array $oneOffPaymentOptions = [])
+    {
+        // Normalize the payment options. Remove this to prevent 422 from Mollie
+        unset($oneOffPaymentOptions['currency']);
+
+        $builder = new OneOffPaymentBuilder($this, $oneOffPaymentOptions);
+        $builder->forItems($items);
+        $builder->setRedirectUrl(config('cashier.one_off_payment.redirect_url'));
+        $builder->setWebhookUrl(config('cashier.one_off_payment.webhook_url'));
+        $builder->setDescription(config('cashier.one_off_payment.description'));
+        $builder->setPaymentMethods(config('cashier.one_off_payment.active_payment_methods'));
+
+        return RedirectToCheckoutResponse::forPayment($builder->create());
+    }
+
+    /**
+     * Get the entity's upcoming invoice in memory. You can inspect it,
+     * and if you like what you see you can use the `invoice` method.
+     *
+     * @param array $overrides
+     * @return \Laravel\Cashier\Order\Order|bool
+     */
+    public function upcomingInvoice(array $overrides = [])
+    {
+        $parameters = array_merge(['currency' => Cashier::usesCurrency()], $overrides);
+        $parameters['currency'] = Str::upper($parameters['currency']);
+
+        $items = OrderItem::shouldProcess()
+            ->forOwner($this)
+            ->ofCurrency($parameters['currency'])
+            ->get();
+
+        if ($items->isEmpty()) {
+            return false;
+        }
+
+        return Order::make($this, $items, $parameters);
+    }
+}

--- a/src/Traits/ParsesAndUpdatesRedirectUrls.php
+++ b/src/Traits/ParsesAndUpdatesRedirectUrls.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Laravel\Cashier\Traits;
+
+use Illuminate\Support\Str;
+use Mollie\Api\Resources\Payment;
+
+trait ParsesAndUpdatesRedirectUrls
+{
+    /**
+     * Replace any placeholders in the payment redirect url
+     *
+     * @param \Mollie\Api\Resources\Payment $payment
+     * @param string $redirectUrl
+     * @return \Mollie\Api\Resources\Payment
+     */
+    public function parseAndUpdateRedirectUrl(Payment $payment, $redirectUrl)
+    {
+        if (!Str::contains($redirectUrl, '{payment_id}')) {
+            return $payment;
+        }
+
+        $payment->redirectUrl = Str::replaceArray('{payment_id}', [$payment->id], $redirectUrl);
+
+        return $payment->update();
+    }
+}

--- a/tests/BillableTest.php
+++ b/tests/BillableTest.php
@@ -130,5 +130,4 @@ class BillableTest extends BaseTestCase
             return true;
         });
     }
-
 }

--- a/tests/OneOffPayment/ManagesInvoicesTest.php
+++ b/tests/OneOffPayment/ManagesInvoicesTest.php
@@ -1,0 +1,293 @@
+<?php
+
+namespace Laravel\Cashier\Tests\OneOffPayment;
+
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Facades\Event;
+use Laravel\Cashier\Cashier;
+use Laravel\Cashier\Events\OrderCreated;
+use Laravel\Cashier\Events\OrderPaymentFailed;
+use Laravel\Cashier\Events\OrderPaymentPaid;
+use Laravel\Cashier\Events\OrderProcessed;
+use Laravel\Cashier\Order\Invoice;
+use Laravel\Cashier\Order\Order;
+use Laravel\Cashier\Order\OrderItem;
+use Laravel\Cashier\SubscriptionBuilder\RedirectToCheckoutResponse;
+use Laravel\Cashier\Tests\BaseTestCase;
+use Laravel\Cashier\Tests\Fixtures\User;
+use Mollie\Api\Resources\Payment;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+class ManagesInvoicesTest extends BaseTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->withPackageMigrations();
+    }
+
+    /** @test */
+    public function canFindInvoices()
+    {
+        $user = $this->getCustomerUser();
+        $items = factory(OrderItem::class, 2)
+            ->states(['EUR'])
+            ->create([
+                'owner_id' => $user->getKey(),
+                'owner_type' => $user->getMorphClass(),
+                'unit_price' => 12150,
+                'quantity' => 1,
+                'tax_percentage' => 21.5,
+                'orderable_type' => null,
+                'orderable_id' => null,
+            ]);
+        $order = Order::createFromItems($items);
+
+        $createdInvoice = $order->fresh()->invoice();
+        $foundInvoice = $user->findInvoice($order->id);
+
+        $this->assertEquals($createdInvoice, $foundInvoice);
+        $this->assertNull($user->findInvoice('non-existing-order'));
+    }
+
+    /** @test */
+    public function canFindInvoiceOrFail()
+    {
+        $user = $this->getCustomerUser();
+        $items = factory(OrderItem::class, 2)
+            ->states(['unlinked', 'EUR'])
+            ->create([
+                'owner_id' => $user->id,
+                'owner_type' => User::class,
+                'unit_price' => 12150,
+                'quantity' => 1,
+                'tax_percentage' => 21.5,
+            ]);
+        $order = Order::createFromItems($items, [
+            'balance_before' => 500,
+            'credit_used' => 500,
+            'owner_type' => $user->getMorphClass(),
+            'owner_id' => $user->getKey(),
+        ]);
+
+        $createdInvoice = $order->fresh()->invoice();
+        $foundInvoice = $user->findInvoiceOrFail($order->id);
+
+        $this->assertEquals($createdInvoice, $foundInvoice);
+
+        $this->expectException(NotFoundHttpException::class);
+        $this->assertNull($user->findInvoiceOrFail('non-existing-order'));
+    }
+
+    /** @test */
+    public function canAddSomethingOnAUsersTab()
+    {
+        $customerUser = $this->getMandatedUser();
+
+        $orderItem = $customerUser->tab('A potato', 100, [
+            'currency' => $currency = 'usd',
+        ]);
+
+        $this->assertInstanceOf(OrderItem::class, $orderItem);
+        $this->assertTrue($orderItem->owner->is($customerUser));
+        $this->assertSame($orderItem->getCurrency(), 'USD');
+    }
+
+    /** @test */
+    public function canInvoiceOpenTabWithoutAMandate()
+    {
+        Event::fake();
+
+        // To prove it takes the default currency when invoicing by default.
+        Cashier::useCurrency('usd');
+
+        $customerUser = $this->getCustomerUser();
+
+        // We put something on the tab in EUR
+        $customerUser->tab('A potato', 100, [
+            'currency' => $currency = 'eur',
+        ]);
+
+        // The default currency is 'USD', we don't have any open tab for the default currency
+        $createdOrder = $customerUser->invoice();
+        $this->assertFalse($createdOrder);
+
+        // We get a redirect to pay for the invoice.
+        $response = $customerUser->invoice(['currency' => $currency]);
+        $this->assertInstanceOf(RedirectResponse::class, $response);
+        $this->assertInstanceOf(RedirectToCheckoutResponse::class, $response);
+        $this->assertInstanceOf(Payment::class, $response->payment());
+        $this->assertFalse($customerUser->validMollieMandate());
+
+        Event::assertNotDispatched(OrderProcessed::class);
+        Event::assertNotDispatched(OrderCreated::class);
+
+        Cashier::useCurrency('eur'); // reset
+
+        // Use this payment ID after checking out at the URL:
+        // - set status to paid > test the successful webhook test.
+        // - set status to failed > test the failed webhook test.
+        // dd(
+        //     $response->payment()->id,
+        //     $response->payment()->_links->checkout
+        // );
+    }
+
+    /** @test */
+    public function canInvoiceOpenTabWhenHavingAMandate()
+    {
+        Event::fake();
+
+        $mandatedCustomer = $this->getMandatedUser();
+        $this->assertTrue($mandatedCustomer->validMollieMandate());
+
+        // We put something on the tab in EUR
+        $mandatedCustomer->tab('A potato', 100);
+
+        // We have an order
+        $order = $mandatedCustomer->invoice();
+
+        // Order got processed
+        $this->assertTrue($order->isProcessed());
+        $this->assertTrue($mandatedCustomer->validMollieMandate());
+        $this->assertInstanceOf(Order::class, $order);
+        Event::assertDispatched(OrderCreated::class, function ($e) use ($order) {
+            return $e->order->is($order);
+        });
+        Event::assertDispatched(OrderProcessed::class, function(OrderProcessed $event) use ($order) {
+            return $event->order->is($order);
+        });
+    }
+
+    /** @test */
+    public function canInvoiceForWithAValidMandate()
+    {
+        Event::fake();
+        $mandatedUser = $this->getMandatedUser();
+
+        $createdOrder = $mandatedUser->invoiceFor('A potato', 100);
+        $this->assertInstanceOf(Order::class, $createdOrder);
+        $this->assertMoneyEURCents(100, $createdOrder->getTotal());
+
+        // We have the associated order.
+        /** @var Order $order */
+        $foundOrder = $mandatedUser->orders->first();
+        $this->assertInstanceOf(Order::class, $foundOrder);
+        $this->assertMoneyEURCents(100, $foundOrder->getTotal());
+        $this->assertEquals($foundOrder, $createdOrder->fresh());
+        Event::assertDispatched(OrderCreated::class, function ($e) use ($createdOrder) {
+            return $e->order->is($createdOrder);
+        });
+        Event::assertDispatched(OrderProcessed::class, function(OrderProcessed $event) use ($createdOrder) {
+            return $event->order->is($createdOrder);
+        });
+    }
+
+    /** @test */
+    public function canOverrideCurrencyWhenUsingInvoiceFor()
+    {
+        Event::fake();
+        Cashier::useCurrency('usd');
+
+        $mandatedUser = $this->getMandatedUser();
+
+        // We wish to create an invoice for a non default currency
+        // The invoice should automatically be made in the appropriate currency,
+        // even if the user doesn't specify it in the payment options.
+        $createdOrder = $mandatedUser->invoiceFor('A potato', 100, [
+            'currency' => 'eur' // non default currency
+        ]);
+        $this->assertInstanceOf(Order::class, $createdOrder);
+        $this->assertMoneyEURCents(100, $createdOrder->getTotal());
+
+        // We have the associated order.
+        /** @var Order $order */
+        $foundOrder = $mandatedUser->orders->first();
+        $this->assertInstanceOf(Order::class, $foundOrder);
+        $this->assertMoneyEURCents(100, $foundOrder->getTotal());
+        $this->assertEquals($foundOrder, $createdOrder->fresh());
+        Event::assertDispatched(OrderCreated::class, function ($e) use ($createdOrder) {
+            return $e->order->is($createdOrder);
+        });
+        Event::assertDispatched(OrderProcessed::class, function(OrderProcessed $event) use ($createdOrder) {
+            return $event->order->is($createdOrder);
+        });
+
+        Cashier::useCurrency('eur'); // reset
+    }
+
+    /** @test */
+    public function handlesSuccessfulOneOffPaymentWebhookEvents()
+    {
+        Event::fake();
+        $this->withoutExceptionHandling();
+        $user = $this->getUser();
+        $orderItem = factory(OrderItem::class)->create();
+
+        $response = $this->post(
+            route('webhooks.mollie.one_off_payment', ['id' => $paymentPaidId = env('PAYMENT_PAID_ID')])
+        );
+
+        $order = $orderItem->fresh()->order;
+        $response->assertStatus(200);
+
+        Event::assertDispatched(OrderCreated::class, function ($e) use ($order) {
+            return $e->order->is($order);
+        });
+        Event::assertDispatched(OrderProcessed::class, function(OrderProcessed $event) use ($order) {
+            return $event->order->is($order);
+        });
+        Event::assertDispatched(OrderPaymentPaid::class, function(OrderPaymentPaid $event) use ($order) {
+            return $event->order->is($order);
+        });
+    }
+
+    /** @test */
+    public function handlesFailedOneOffPaymentWebhookEvents()
+    {
+        Event::fake();
+        $this->withoutExceptionHandling();
+        $order = factory(Order::class)->create([
+            // @see ManagesInvoicesTest@canInvoiceOpenTabWithoutAMandate
+            'mollie_payment_id' => $failedPaymentId = env('PAYMENT_FAILED_ID')
+        ]);
+
+        $this->getMandatedUser();
+
+        $response = $this->post(
+            route('webhooks.mollie.default', ['id' => $failedPaymentId])
+        );
+
+        $response->assertStatus(200);
+
+        Event::assertDispatched(OrderPaymentFailed::class, function(OrderPaymentFailed $event) use ($order) {
+            return $event->order->is($order);
+        });
+    }
+
+    /** @test */
+    public function canGetTheUpcomingInvoice()
+    {
+        $user = $this->getUser(true, ['tax_percentage' => 10]);
+        $user->tab('A premium quality potato', 1000);
+        $user->tab('A high quality carrot', 800);
+
+        $inMemoryOrder = $user->upcomingInvoice(['number' => 'Concept']);
+
+        $this->assertFalse($inMemoryOrder->exists);
+        $this->assertFalse($inMemoryOrder->isProcessed());
+        $this->assertSame('Concept', $inMemoryOrder->number);
+        $this->assertMoneyEURCents(180, $inMemoryOrder->getTax());
+        $this->assertMoneyEURCents(1800, $inMemoryOrder->getSubtotal());
+        $this->assertMoneyEURCents(1980, $inMemoryOrder->getTotal());
+        $this->assertInstanceOf(Invoice::class, $inMemoryOrder->invoice());
+
+        $firstItem = $inMemoryOrder->items->first();
+        $secondItem = $inMemoryOrder->items->last();
+        $this->assertInstanceOf(OrderItem::class, $firstItem);
+        $this->assertInstanceOf(OrderItem::class, $secondItem);
+        $this->assertSame('A premium quality potato', $firstItem->description);
+        $this->assertSame('A high quality carrot', $secondItem->description);
+    }
+}

--- a/tests/OneOffPayment/OneOffPaymentBuilderTest.php
+++ b/tests/OneOffPayment/OneOffPaymentBuilderTest.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace Laravel\Cashier\Tests\OneOffPayment;
+
+use Laravel\Cashier\OneOffPayment\OneOffPaymentBuilder;
+use Laravel\Cashier\Order\OrderItem;
+use Laravel\Cashier\Tests\BaseTestCase;
+use Laravel\Cashier\Tests\Fixtures\User;
+use Mollie\Api\Resources\Payment;
+use Mollie\Api\Types\SequenceType;
+
+class OneOffPaymentBuilderTest extends BaseTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->withPackageMigrations();
+    }
+
+    /** @test */
+    public function canBuildPayload()
+    {
+        $owner = factory(User::class)->create();
+
+        $builder = new OneOffPaymentBuilder($owner, [
+            'description' => 'Test mandate payment',
+            'redirectUrl' => 'https://www.example.com',
+            'webhookUrl' => 'https://www.example.com/mandate-webhook'
+        ]);
+
+        $builder->forItems(
+            $items = factory(OrderItem::class, 2)
+                ->states(['unlinked', 'unprocessed', 'EUR'])
+                ->create([
+                    'owner_type' => $owner->getMorphClass(),
+                    'owner_id' => $owner->getKey(),
+                    'unit_price' => 300,
+                    'tax_percentage' => 10,
+                ])
+        );
+
+        $payload = $builder->getMolliePayload();
+        $customerId = $payload['customerId'];
+        unset($payload['customerId']);
+        $check_payload = [
+            'sequenceType' => SequenceType::SEQUENCETYPE_ONEOFF,
+            'description' => 'Test mandate payment',
+            'amount' => [
+                'value' => '6.60',
+                'currency' => 'EUR',
+            ],
+            'redirectUrl' => 'https://www.example.com',
+            'webhookUrl' => 'https://www.example.com/mandate-webhook',
+            'metadata' => [
+                'owner' => [
+                    'type' => $owner->getMorphClass(),
+                    'id' => $owner->getKey(),
+                ],
+                'items' => $items->toArray(),
+            ],
+        ];
+        $this->assertEquals($check_payload, $payload);
+        $this->assertNotEmpty($customerId);
+    }
+
+    /** @test */
+    public function createsMolliePayment()
+    {
+        $owner = $this->getMandatedUser();
+
+        $builder = new OneOffPaymentBuilder($owner, [
+            'description' => 'Test mandate payment',
+            'redirectUrl' => 'https://www.example.com',
+        ]);
+
+        $builder->forItems(
+            $items = factory(OrderItem::class, 2)
+                ->states(['unlinked', 'unprocessed', 'EUR'])
+                ->create([
+                    'owner_type' => $owner->getMorphClass(),
+                    'owner_id' => $owner->getKey(),
+                    'unit_price' => 300,
+                    'tax_percentage' => 10,
+                ])
+        );
+
+        $payment = $builder->create();
+
+        $this->assertInstanceOf(Payment::class, $payment);
+    }
+
+    /** @test */
+    public function parsesRedirectUrlPaymentIdUponPaymentCreation()
+    {
+        $owner = factory(User::class)->create();
+
+        $builder = new OneOffPaymentBuilder($owner, [
+            'redirectUrl' => 'https://www.example.com/{payment_id}',
+        ]);
+
+        $payment = $builder->forItems(
+            factory(OrderItem::class, 1)->create()
+        )->create();
+
+        $this->assertStringContainsString($payment->id, $payment->redirectUrl);
+    }
+}


### PR DESCRIPTION
This pull request closes #42.

There are a few things that still need to be done, and on which I would appreciate your input (@sandervanhooft). 

### Order items "on the tab" collision (?) with Subscription order items.

Currently, because of the nature of the subscription billing implementation, the 'open tab' may collide  with subscription billing. 

Example 1: calling `$user->invoice()` may end up invoicing subscription items if they are due for processing (could be the intended functionality?). 
Example 2: `php artisan cashier:run` will invoice the items that we put on the tab, once they are due for processing.

If we intend to split apart subscription billing and one off payments, we can add an extra table `tab_items` that simply points to the `id` of an order item that is supposed to be on the tab. After that we can add two scopes `onTheTab` and `forSubscriptions` (naming up for discussion of course), and add the `forSubscriptions` scope to `Cashier::run`, as well as the `onTheTab` scope to the `invoice` method.

My assumption was/is that you would prefer not to split this apart, since it could be nice if a developer can put an extra item on the customers next bill (complementary to the fee for the subscription).

In this case we would need to document this properly, and in my opinion also write some extra tests that do some checking on the aforementioned scenario (subscription + one off payment complimentary usage).

### Double checking the payment flow for one off payments
Though this is pretty obvious, you may want to double check if the one off payment flow that is implemented is correct. A quick summary:

Scenario 1:
- Customer has a valid mandate
- One off payment initiated by developer
- Prevent if there are no order items that are due for processing
- We create an invoice + process the payment

Scenario 2:
- Customer doesn't have a valid mandate
- One off payment initiated by developer
- Prevent if there are no order items that are due for processing
- We create a payment at Mollie, and redirect the customer to the checkout
- Mollie calls our webhook.
    - if successful we create an order. (`OrderPaymentPaid` event)
    - if failed we don't create an order, so the tab stays open. (`OrderPaymentFailed` event)

This flow is quite the same as the "first payment" flow, except the fact that we are creating a "one off payment", which means we don't create a mandate in the process.

Something you will notice is that the "one off payment flow" is **not** using/hooking onto the `Actions` that are currently a feature for subscriptions. This was done on purpose, since I couldn't think of a scenario where you would want to do "anything fancy" with a one off payment. This also means that instead of storing `actions` in the Mollie Payment metadata, we are simply storing the `order items`. If someone can think of a valid reason to introduce the extra layer of complexity (the actions), we could revisit this implementation.

### Double check the written tests
I'm not completely up to speed with your usual event dispatching for example, in the end I haven't used this package since `1.0` because there were no "one off payment" possibilities, which was my main use case in the application I was building. Kindly check if the tests are up to par, and if they need to be improved/extended.

### Notes

- The `Laravel\Cashier\SubscriptionBuilder\RedirectToCheckoutResponse` class has been reused (for developer friendliness), even though the namespace is now kind of weird; maybe we should flag this as something that can be improved in V2? (since it's a breaking change to move it to a different namespace)

- Instead of using `get_class($user)` I used `$user->getMorphClass()`, which supports [Laravels MorphMap](https://laravel.com/docs/eloquent-relationships#custom-polymorphic-types) (I noticed later you used `get_class()`). You could see this as a breaking change. If a developer has defined a morph map for their `User` model, it will now use the defined string by the developer instead of the fully qualified name of the `User` model (though chances are probably _very low_ the generic developer is using this [this is an assumption though :)]). I noticed this later, as well as the assumption we're currently making that the user will always have an `id` column (`$owner->id` calls). We should replace this with `$owner->getKey()` instead in the future, so we support different primary key names. Let me know what your thought are on the above.

## To do's
- [ ] Add 2 extra variables to the `phpunit.xml` for usage in `ManagesInvoiceTest.php`, since one off payments have a different Mollie Payment metadata (they use the `order items`, not the `actions` after all.
- [ ] (?) Might as well create a simply "entrypoint" for developers, from where they can run 1 test, and copy paste all the necessary Mollie id's to their `phpunit.xml`. This will (in my opinion) greatly improve onboarding of developers for pull requests (perhaps other pull request?).
- [ ] Change `->getMorphClass()` calls to `get_class`.
- [ ] (?) Someone will need to add some extra tests for one off payment + subscription complimentary usage.

Let me know your thought on this so far.
