### PR TITLE
added previousPlan to SubscriptionPlanSwapped Event

### DIFF
--- a/src/Billable.php
+++ b/src/Billable.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Cashier;
 
+use Dompdf\Options;
 use Illuminate\Support\Facades\DB;
 use InvalidArgumentException;
 use Laravel\Cashier\Coupon\Contracts\CouponRepository;
@@ -384,14 +385,15 @@ trait Billable
      * @param $orderId
      * @param null|array $data
      * @param string $view
+     * @param \Dompdf\Options $options
      * @return \Symfony\Component\HttpFoundation\Response
      */
-    public function downloadInvoice($orderId, $data = [], $view = Invoice::DEFAULT_VIEW)
+    public function downloadInvoice($orderId, $data = [], $view = Invoice::DEFAULT_VIEW, Options $options = null)
     {
         /** @var Order $order */
         $order = $this->orders()->where('id', $orderId)->firstOrFail();
 
-        return $order->invoice()->download($data, $view);
+        return $order->invoice()->download($data, $view, $options);
     }
 
     /**

--- a/src/CashierServiceProvider.php
+++ b/src/CashierServiceProvider.php
@@ -14,7 +14,7 @@ use Mollie\Laravel\MollieServiceProvider;
 
 class CashierServiceProvider extends ServiceProvider
 {
-    const PACKAGE_VERSION = '1.13.0';
+    const PACKAGE_VERSION = '1.13.1';
 
     /**
      * Bootstrap the application services.

--- a/src/CashierServiceProvider.php
+++ b/src/CashierServiceProvider.php
@@ -14,7 +14,7 @@ use Mollie\Laravel\MollieServiceProvider;
 
 class CashierServiceProvider extends ServiceProvider
 {
-    const PACKAGE_VERSION = '1.12.0';
+    const PACKAGE_VERSION = '1.12.1';
 
     /**
      * Bootstrap the application services.

--- a/src/CashierServiceProvider.php
+++ b/src/CashierServiceProvider.php
@@ -14,7 +14,7 @@ use Mollie\Laravel\MollieServiceProvider;
 
 class CashierServiceProvider extends ServiceProvider
 {
-    const PACKAGE_VERSION = '1.12.2';
+    const PACKAGE_VERSION = '1.13.0';
 
     /**
      * Bootstrap the application services.

--- a/src/CashierServiceProvider.php
+++ b/src/CashierServiceProvider.php
@@ -14,7 +14,7 @@ use Mollie\Laravel\MollieServiceProvider;
 
 class CashierServiceProvider extends ServiceProvider
 {
-    const PACKAGE_VERSION = '1.12.1';
+    const PACKAGE_VERSION = '1.12.2';
 
     /**
      * Bootstrap the application services.

--- a/src/Events/SubscriptionPlanSwapped.php
+++ b/src/Events/SubscriptionPlanSwapped.php
@@ -14,8 +14,17 @@ class SubscriptionPlanSwapped
      */
     public $subscription;
 
-    public function __construct(Subscription $subscription)
+    /**
+     * The previous subscription plan before swapping if exists.
+     *
+     * @var mixed
+     */
+    public $previousPlan;
+
+    public function __construct(Subscription $subscription, $previousPlan = null)
     {
         $this->subscription = $subscription;
+
+        $this->previousPlan = $previousPlan;
     }
 }

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -419,8 +419,14 @@ class Subscription extends Model implements InteractsWithOrderItems, Preprocesse
                 'unit_price' => (int) $plan->amount()->getAmount(),
                 'quantity' => $this->quantity ?: 1,
                 'tax_percentage' => $this->tax_percentage,
+<<<<<<< HEAD
                 'description' => $plan->description(),
             ], $item_overrides
+=======
+                'description' => $plan()->description(),
+            ],
+            $item_overrides
+>>>>>>> get description from available plan to reslove conflict
         ));
 
         if ($fill_link) {

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -160,12 +160,12 @@ class Subscription extends Model implements InteractsWithOrderItems, Preprocesse
         $cycle_ends_at = $this->cancelled() ? $this->ends_at->copy() : $this->cycle_ends_at->copy();
 
         // Cycle completed
-        if($cycle_ends_at->lessThanOrEqualTo($now)) {
+        if ($cycle_ends_at->lessThanOrEqualTo($now)) {
             return 1;
         }
 
         // Cycle not yet started
-        if($cycle_started_at->greaterThanOrEqualTo($now)) {
+        if ($cycle_started_at->greaterThanOrEqualTo($now)) {
             return 0;
         }
 
@@ -202,12 +202,12 @@ class Subscription extends Model implements InteractsWithOrderItems, Preprocesse
         $newPlan = app(PlanRepository::class)::findOrFail($plan);
         $previousPlan = $this->plan;
 
-        if($this->cancelled()) {
+        if ($this->cancelled()) {
             $this->cycle_ends_at = $this->ends_at;
             $this->ends_at = null;
         }
 
-        $applyNewSettings = function() use ($newPlan) {
+        $applyNewSettings = function () use ($newPlan) {
             $this->plan = $newPlan->name();
         };
 
@@ -315,13 +315,13 @@ class Subscription extends Model implements InteractsWithOrderItems, Preprocesse
     {
         $item = $this->scheduledOrderItem;
 
-        if($item && $item->isProcessed(false)) {
+        if ($item && $item->isProcessed(false)) {
             $item->delete();
         }
 
         $this->fill(['scheduled_order_item_id' => null]);
 
-        if($save) {
+        if ($save) {
             $this->save();
         }
 
@@ -402,16 +402,16 @@ class Subscription extends Model implements InteractsWithOrderItems, Preprocesse
      */
     public function scheduleNewOrderItemAt(Carbon $process_at, $item_overrides = [], $fill_link = true, Plan $plan = null)
     {
-        if($this->scheduled_order_item_id)
-        {
+        if ($this->scheduled_order_item_id) {
             throw new LogicException('Cannot schedule a new subscription order item if there is already one scheduled.');
         }
 
-        if(is_null($plan)) {
+        if (is_null($plan)) {
             $plan = $this->plan();
         }
 
-        $item = $this->orderItems()->create(array_merge([
+        $item = $this->orderItems()->create(array_merge(
+            [
                 'owner_id' => $this->owner_id,
                 'owner_type' => $this->owner_type,
                 'process_at' => $process_at,
@@ -459,7 +459,7 @@ class Subscription extends Model implements InteractsWithOrderItems, Preprocesse
         $plan_swapped = false;
         $previousPlan = null;
 
-        if(! empty($subscription->next_plan)) {
+        if (! empty($subscription->next_plan)) {
             $plan_swapped = true;
             $previousPlan = $subscription->plan;
             $subscription->plan = $subscription->next_plan;
@@ -619,7 +619,7 @@ class Subscription extends Model implements InteractsWithOrderItems, Preprocesse
 
         $oldQuantity = $this->quantity;
 
-        $this->restartCycleWithModifications(function() use ($quantity) {
+        $this->restartCycleWithModifications(function () use ($quantity) {
             $this->quantity = $quantity;
         }, now(), $invoiceNow);
 
@@ -668,7 +668,7 @@ class Subscription extends Model implements InteractsWithOrderItems, Preprocesse
     protected function reimburseUnusedTime(?Carbon $now = null)
     {
         $now = $now ?: now();
-        if($this->onTrial()) {
+        if ($this->onTrial()) {
             return null;
         }
 
@@ -701,11 +701,10 @@ class Subscription extends Model implements InteractsWithOrderItems, Preprocesse
             // Apply new subscription settings
             call_user_func($applyNewSettings);
 
-            if($this->onTrial()) {
+            if ($this->onTrial()) {
 
                 // Reschedule next cycle's OrderItem using the new subscription settings
                 $orderItems[] = $this->scheduleNewOrderItemAt($this->trial_ends_at);
-
             } else { // Start a new billing cycle using the new subscription settings
 
                 // Reset the billing cycle
@@ -718,7 +717,7 @@ class Subscription extends Model implements InteractsWithOrderItems, Preprocesse
 
             $this->save();
 
-            if($invoiceNow) {
+            if ($invoiceNow) {
                 $order = Order::createFromItems($orderItems);
                 $order->processPayment();
             }
@@ -736,7 +735,8 @@ class Subscription extends Model implements InteractsWithOrderItems, Preprocesse
      */
     public function restartCycle(?Carbon $now = null, $invoiceNow = true)
     {
-        return $this->restartCycleWithModifications(function() {}, $now, $invoiceNow);
+        return $this->restartCycleWithModifications(function () {
+        }, $now, $invoiceNow);
     }
 
     /**

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -419,14 +419,8 @@ class Subscription extends Model implements InteractsWithOrderItems, Preprocesse
                 'unit_price' => (int) $plan->amount()->getAmount(),
                 'quantity' => $this->quantity ?: 1,
                 'tax_percentage' => $this->tax_percentage,
-<<<<<<< HEAD
                 'description' => $plan->description(),
             ], $item_overrides
-=======
-                'description' => $plan()->description(),
-            ],
-            $item_overrides
->>>>>>> get description from available plan to reslove conflict
         ));
 
         if ($fill_link) {


### PR DESCRIPTION
I was in need to know what plan the subscription has previously before it swapped. Specially on subscriptions that swapNextCycle there is no reference when the event **SubscriptionPlanSwapped** gets called. So i just added the previous plan to the SubscriptionPlanSwapped event with a temporary variable.

This will helps if you need to do a specific task based on the previous and new plan. Maybe a "Thanks for Upgrade" or "Thanks for Downgrade" email to the customer.

If there was no previous plan the $event->previousPlan will be NULL.

_Sorry for the most changes made by PHP-CS-Fixer (PSR-2)._