### PR TITLE
Bugfix in Subscription::scheduleNewOrderItemAt

### DIFF
--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -418,7 +418,7 @@ class Subscription extends Model implements InteractsWithOrderItems, Preprocesse
                 'unit_price' => (int) $plan->amount()->getAmount(),
                 'quantity' => $this->quantity ?: 1,
                 'tax_percentage' => $this->tax_percentage,
-                'description' => $this->plan()->description(),
+                'description' => $plan->description(),
             ], $item_overrides
         ));
 

--- a/tests/SwapSubscriptionPlanTest.php
+++ b/tests/SwapSubscriptionPlanTest.php
@@ -138,6 +138,7 @@ class SwapSubscriptionPlanTest extends BaseTestCase
         $this->assertCarbon($cycle_should_end_at, $new_order_item->process_at, 1); // based on previous plan's cycle
         $this->assertEquals(2200, $new_order_item->total);
         $this->assertEquals(200, $new_order_item->tax);
+        $this->assertEquals('Twice as expensive monthly subscription', $new_order_item->description);
 
         $this->assertFalse($user->fresh()->hasCredit());
 


### PR DESCRIPTION
the method didn't respect the plan given as optional parameter for the description of the scheduled new order item and always used the description of the old one instead
fixes #217