### PR TITLE
Orders paid by credit don't need a mandate check

### DIFF
--- a/tests/Order/OrderTest.php
+++ b/tests/Order/OrderTest.php
@@ -434,6 +434,60 @@ class OrderTest extends BaseTestCase
         $this->assertMoneyEURCents(29998, $user->credit('EUR')->money());
     }
 
+    /**
+     * @test
+     */
+    public function canCreateOrderFromOrderItemsWhenTotalIsPaidByCreditAndOwnerHasNoMandate()
+    {
+        Carbon::setTestNow(Carbon::parse('2018-01-01'));
+        Event::fake();
+        $user = factory(User::class)->create(); // user without subscription/mandate
+        $user->addCredit(money(29998, 'EUR'));
+
+        factory(OrderItem::class, 2)->create([
+            'orderable_type' => null,
+            'orderable_id' => null,
+            'process_at' => now()->subMinute(), // sub minute so we're sure it's ready to be processed
+            'owner_id' => $user->id,
+            'owner_type' => get_class($user),
+            'currency' => 'EUR',
+            'quantity' => 1,
+            'unit_price' => 12345, // includes vat
+            'tax_percentage' => 21.5,
+        ]);
+
+        $order = Order::createFromItems(OrderItem::all());
+
+        $this->assertEquals(2, $order->items()->count());
+
+        $this->assertEquals($user->id, $order->owner_id);
+        $this->assertEquals(User::class, $order->owner_type);
+        $this->assertEquals('EUR', $order->currency);
+        $this->assertEquals(24690, $order->subtotal);
+        $this->assertMoneyEURCents(24690, $order->getSubtotal());
+        $this->assertEquals(5308, $order->tax);
+        $this->assertMoneyEURCents(5308, $order->getTax());
+        $this->assertEquals(29998, $order->total);
+        $this->assertMoneyEURCents(29998, $order->getTotal());
+        $this->assertEquals(0, $order->total_due);
+        $this->assertMoneyEURCents(0, $order->getTotalDue());
+        $this->assertEquals('2018-0000-0001', $order->number);
+        $this->assertNull($order->mollie_payment_id);
+
+        Event::assertDispatched(OrderCreated::class, function ($e) use ($order) {
+            return $e->order->is($order);
+        });
+
+        $order->processPayment();
+
+        $this->assertDispatchedOrderProcessed($order);
+
+        $this->assertNull($order->mollie_payment_id);
+        $this->assertEquals(null, $order->mollie_payment_status);
+
+        $this->assertMoneyEURCents(0, $user->credit('EUR')->money());
+    }
+
     /** @test */
     public function canCreateProcessedOrderFromItems()
     {


### PR DESCRIPTION
As I've mentioned in #183, if an order can be paid by a user's credit, there's no need to check for a mandate. I therefore moved this mandate check to the point where the `total_due` was calculated and based on this I performed the mandate check after the user's credit was applied.