### PR TITLE
Extract mollie interactions

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -23,6 +23,7 @@
     <groups>
         <exclude>
             <group>generate_new_invoice_template</group>
+            <group>mollie_integration</group>
         </exclude>
     </groups>
     <php>

--- a/src/Billable.php
+++ b/src/Billable.php
@@ -70,13 +70,7 @@ trait Billable
     public function newSubscription($subscription, $plan, $firstPaymentOptions = [])
     {
         if(! empty($this->mollie_mandate_id)) {
-
-            $mandate = null;
-
-            try {
-                $mandate = $this->asMollieCustomer()->getMandate($this->mollie_mandate_id);
-            } catch (ApiException $e) {} // A revoked mandate may no longer exist, so throws an exception
-
+            $mandate = $this->mollieMandate();
             $planModel = app(PlanRepository::class)::findOrFail($plan);
             $method = MandateMethod::getForFirstPaymentMethod($planModel->firstPaymentMethod());
 

--- a/src/Billable.php
+++ b/src/Billable.php
@@ -168,6 +168,7 @@ trait Billable
         if(empty($this->mollie_customer_id)) {
             return $this->createAsMollieCustomer();
         }
+
         return mollie()->customers()->get($this->mollie_customer_id);
     }
 

--- a/src/CashierServiceProvider.php
+++ b/src/CashierServiceProvider.php
@@ -5,6 +5,7 @@ namespace Laravel\Cashier;
 use Illuminate\Support\ServiceProvider;
 use Laravel\Cashier\Console\Commands\CashierInstall;
 use Laravel\Cashier\Console\Commands\CashierRun;
+use Laravel\Cashier\Mollie\RegistersMollieInteractions;
 use Laravel\Cashier\Order\Contracts\MinimumPayment as MinimumPaymentContract;
 use Laravel\Cashier\Coupon\ConfigCouponRepository;
 use Laravel\Cashier\Coupon\Contracts\CouponRepository;
@@ -14,6 +15,8 @@ use Mollie\Laravel\MollieServiceProvider;
 
 class CashierServiceProvider extends ServiceProvider
 {
+    use RegistersMollieInteractions;
+
     const PACKAGE_VERSION = '1.14.0';
 
     /**
@@ -45,6 +48,7 @@ class CashierServiceProvider extends ServiceProvider
     public function register()
     {
         $this->app->register(MollieServiceProvider::class);
+        $this->registerMollieInteractions($this->app);
         $this->app->bind(PlanRepository::class, ConfigPlanRepository::class);
         $this->app->singleton(CouponRepository::class, function () {
             return new ConfigCouponRepository(

--- a/src/FirstPayment/FirstPaymentBuilder.php
+++ b/src/FirstPayment/FirstPaymentBuilder.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Str;
 use Laravel\Cashier\Cashier;
 use Laravel\Cashier\FirstPayment\Actions\ActionCollection;
+use Laravel\Cashier\Mollie\Contracts\CreateMolliePayment;
 use Mollie\Api\Types\SequenceType;
 
 class FirstPaymentBuilder
@@ -121,7 +122,10 @@ class FirstPaymentBuilder
     public function create()
     {
         $payload = $this->getMolliePayload();
-        $this->molliePayment = mollie()->payments()->create($payload);
+
+        /** @var CreateMolliePayment $createMolliePayment */
+        $createMolliePayment = app()->make(CreateMolliePayment::class);
+        $this->molliePayment = $createMolliePayment->execute($payload);
 
         $redirectUrl = $payload['redirectUrl'];
 

--- a/src/FirstPayment/FirstPaymentBuilder.php
+++ b/src/FirstPayment/FirstPaymentBuilder.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Str;
 use Laravel\Cashier\Cashier;
 use Laravel\Cashier\FirstPayment\Actions\ActionCollection;
 use Laravel\Cashier\Mollie\Contracts\CreateMolliePayment;
+use Laravel\Cashier\Mollie\Contracts\UpdateMolliePayment;
 use Mollie\Api\Types\SequenceType;
 
 class FirstPaymentBuilder
@@ -133,7 +134,10 @@ class FirstPaymentBuilder
         if(Str::contains($redirectUrl, '{payment_id}')) {
             $redirectUrl = Str::replaceArray('{payment_id}', [$this->molliePayment->id], $redirectUrl);
             $this->molliePayment->redirectUrl = $redirectUrl;
-            $this->molliePayment = $this->molliePayment->update();
+
+            /** @var UpdateMolliePayment $updateMolliePayment */
+            $updateMolliePayment = app()->make(UpdateMolliePayment::class);
+            $this->molliePayment = $updateMolliePayment->execute($this->molliePayment);
         }
 
         return $this->molliePayment;

--- a/src/Http/Controllers/BaseWebhookController.php
+++ b/src/Http/Controllers/BaseWebhookController.php
@@ -2,10 +2,21 @@
 
 namespace Laravel\Cashier\Http\Controllers;
 
+use Laravel\Cashier\Mollie\Contracts\GetMolliePayment;
 use Mollie\Api\Exceptions\ApiException;
 
 abstract class BaseWebhookController
 {
+    /**
+     * @var \Laravel\Cashier\Mollie\Contracts\GetMolliePayment
+     */
+    protected $getMolliePayment;
+
+    public function __construct(GetMolliePayment $getMolliePayment)
+    {
+        $this->getMolliePayment = $getMolliePayment;
+    }
+
     /**
      * Fetch a payment from Mollie using its ID.
      * Returns null if the payment cannot be retrieved.
@@ -17,7 +28,7 @@ abstract class BaseWebhookController
     public function getPaymentById($id)
     {
         try {
-            return mollie()->payments()->get($id);
+            return $this->getMolliePayment->execute($id);
         } catch (ApiException $e) {
             if(! config('app.debug')) {
                 // Prevent leaking information

--- a/src/MandatedPayment/MandatedPaymentBuilder.php
+++ b/src/MandatedPayment/MandatedPaymentBuilder.php
@@ -4,6 +4,7 @@ namespace Laravel\Cashier\MandatedPayment;
 
 use Illuminate\Database\Eloquent\Model;
 use Laravel\Cashier\Cashier;
+use Laravel\Cashier\Mollie\Contracts\CreateMolliePayment;
 use Mollie\Api\Types\SequenceType;
 use Money\Money;
 
@@ -82,6 +83,9 @@ class MandatedPaymentBuilder
      */
     public function create(array $overrides = [])
     {
-        return mollie()->payments()->create($this->getPayload($overrides));
+        /** @var CreateMolliePayment $createMolliePayment */
+        $createMolliePayment = app()->make(CreateMolliePayment::class);
+
+        return $createMolliePayment->execute($this->getPayload($overrides));
     }
 }

--- a/src/MinimumPayment.php
+++ b/src/MinimumPayment.php
@@ -20,17 +20,4 @@ class MinimumPayment implements MinimumPaymentContract
                 ->minimumAmount
         );
     }
-
-    /**
-     * @param string $mandateId
-     * @param string $currency
-     * @return \Money\Money
-     */
-    public static function forMollieMandateId(string $mandateId, string $currency)
-    {
-        return static::forMollieMandate(
-            mollie()->mandates()->get($mandateId),
-            $currency
-        );
-    }
 }

--- a/src/MinimumPayment.php
+++ b/src/MinimumPayment.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Cashier;
 
+use Laravel\Cashier\Mollie\Contracts\GetMollieMethodMinimumAmount;
 use Laravel\Cashier\Order\Contracts\MinimumPayment as MinimumPaymentContract;
 use Mollie\Api\Resources\Mandate;
 
@@ -14,10 +15,9 @@ class MinimumPayment implements MinimumPaymentContract
      */
     public static function forMollieMandate(Mandate $mandate, $currency)
     {
-        return mollie_object_to_money(
-            mollie()
-                ->methods()->get($mandate->method, ['currency' => $currency])
-                ->minimumAmount
-        );
+        /** @var GetMollieMethodMinimumAmount $getMinimumAmount */
+        $getMinimumAmount = app()->make(GetMollieMethodMinimumAmount::class);
+
+        return $getMinimumAmount->execute($mandate->method, $currency);
     }
 }

--- a/src/Mollie/BaseMollieInteraction.php
+++ b/src/Mollie/BaseMollieInteraction.php
@@ -1,0 +1,19 @@
+<?php
+declare(strict_types=1);
+
+namespace Laravel\Cashier\Mollie;
+
+use Mollie\Laravel\Wrappers\MollieApiWrapper as Mollie;
+
+abstract class BaseMollieInteraction
+{
+    /**
+     * @var \Mollie\Laravel\Facades\Mollie
+     */
+    protected $mollie;
+
+    public function __construct(Mollie $mollie)
+    {
+        $this->mollie = $mollie;
+    }
+}

--- a/src/Mollie/Contracts/CreateMollieCustomer.php
+++ b/src/Mollie/Contracts/CreateMollieCustomer.php
@@ -1,0 +1,11 @@
+<?php
+declare(strict_types=1);
+
+namespace Laravel\Cashier\Mollie\Contracts;
+
+use Mollie\Api\Resources\Customer;
+
+interface CreateMollieCustomer
+{
+    public function execute(array $payload): Customer;
+}

--- a/src/Mollie/Contracts/CreateMolliePayment.php
+++ b/src/Mollie/Contracts/CreateMolliePayment.php
@@ -1,0 +1,11 @@
+<?php
+declare(strict_types=1);
+
+namespace Laravel\Cashier\Mollie\Contracts;
+
+use Mollie\Api\Resources\Payment;
+
+interface CreateMolliePayment
+{
+    public function execute(array $payload): Payment;
+}

--- a/src/Mollie/Contracts/GetMollieCustomer.php
+++ b/src/Mollie/Contracts/GetMollieCustomer.php
@@ -1,0 +1,11 @@
+<?php
+declare(strict_types=1);
+
+namespace Laravel\Cashier\Mollie\Contracts;
+
+use Mollie\Api\Resources\Customer;
+
+interface GetMollieCustomer
+{
+    public function execute(string $id): Customer;
+}

--- a/src/Mollie/Contracts/GetMollieMandate.php
+++ b/src/Mollie/Contracts/GetMollieMandate.php
@@ -1,0 +1,11 @@
+<?php
+declare(strict_types=1);
+
+namespace Laravel\Cashier\Mollie\Contracts;
+
+use Mollie\Api\Resources\Mandate;
+
+interface GetMollieMandate
+{
+    public function execute(string $customerId, string $mandateId): Mandate;
+}

--- a/src/Mollie/Contracts/GetMollieMethodMinimumAmount.php
+++ b/src/Mollie/Contracts/GetMollieMethodMinimumAmount.php
@@ -1,0 +1,11 @@
+<?php
+declare(strict_types=1);
+
+namespace Laravel\Cashier\Mollie\Contracts;
+
+use Money\Money;
+
+interface GetMollieMethodMinimumAmount
+{
+    public function execute(string $method, string $currency): Money;
+}

--- a/src/Mollie/Contracts/GetMolliePayment.php
+++ b/src/Mollie/Contracts/GetMolliePayment.php
@@ -1,0 +1,11 @@
+<?php
+declare(strict_types=1);
+
+namespace Laravel\Cashier\Mollie\Contracts;
+
+use Mollie\Api\Resources\Payment;
+
+interface GetMolliePayment
+{
+    public function execute(string $id): Payment;
+}

--- a/src/Mollie/Contracts/UpdateMolliePayment.php
+++ b/src/Mollie/Contracts/UpdateMolliePayment.php
@@ -1,0 +1,11 @@
+<?php
+declare(strict_types=1);
+
+namespace Laravel\Cashier\Mollie\Contracts;
+
+use Mollie\Api\Resources\Payment;
+
+interface UpdateMolliePayment
+{
+    public function execute(Payment $dirtyPayment): Payment;
+}

--- a/src/Mollie/CreateMollieCustomer.php
+++ b/src/Mollie/CreateMollieCustomer.php
@@ -1,0 +1,15 @@
+<?php
+declare(strict_types=1);
+
+namespace Laravel\Cashier\Mollie;
+
+use Mollie\Api\Resources\Customer;
+use Laravel\Cashier\Mollie\Contracts\CreateMollieCustomer as Contract;
+
+class CreateMollieCustomer extends BaseMollieInteraction implements Contract
+{
+    public function execute(array $payload): Customer
+    {
+        return $this->mollie->customers()->create($payload);
+    }
+}

--- a/src/Mollie/CreateMolliePayment.php
+++ b/src/Mollie/CreateMolliePayment.php
@@ -1,0 +1,15 @@
+<?php
+declare(strict_types=1);
+
+namespace Laravel\Cashier\Mollie;
+
+use Mollie\Api\Resources\Payment;
+use Laravel\Cashier\Mollie\Contracts\CreateMolliePayment as Contract;
+
+class CreateMolliePayment extends BaseMollieInteraction implements Contract
+{
+    public function execute(array $payload): Payment
+    {
+        return $this->mollie->payments()->create($payload);
+    }
+}

--- a/src/Mollie/GetMollieCustomer.php
+++ b/src/Mollie/GetMollieCustomer.php
@@ -1,0 +1,15 @@
+<?php
+declare(strict_types=1);
+
+namespace Laravel\Cashier\Mollie;
+
+use Mollie\Api\Resources\Customer;
+use Laravel\Cashier\Mollie\Contracts\GetMollieCustomer as Contract;
+
+class GetMollieCustomer extends BaseMollieInteraction implements Contract
+{
+    public function execute(string $id): Customer
+    {
+        return $this->mollie->customers()->get($id);
+    }
+}

--- a/src/Mollie/GetMollieMandate.php
+++ b/src/Mollie/GetMollieMandate.php
@@ -1,0 +1,15 @@
+<?php
+declare(strict_types=1);
+
+namespace Laravel\Cashier\Mollie;
+
+use Mollie\Api\Resources\Mandate;
+use Laravel\Cashier\Mollie\Contracts\GetMollieMandate as Contract;
+
+class GetMollieMandate extends BaseMollieInteraction implements Contract
+{
+    public function execute(string $customerId, string $mandateId): Mandate
+    {
+        return $this->mollie->mandates()->getForId($customerId, $mandateId);
+    }
+}

--- a/src/Mollie/GetMollieMethodMinimumAmount.php
+++ b/src/Mollie/GetMollieMethodMinimumAmount.php
@@ -1,0 +1,19 @@
+<?php
+declare(strict_types=1);
+
+namespace Laravel\Cashier\Mollie;
+
+use Money\Money;
+
+class GetMollieMethodMinimumAmount extends BaseMollieInteraction implements Contracts\GetMollieMethodMinimumAmount
+{
+    public function execute(string $method, string $currency): Money
+    {
+        $minimumAmount = $this->mollie
+            ->methods()
+            ->get($method, ['currency' => $currency])
+            ->minimumAmount;
+
+        return mollie_object_to_money($minimumAmount);
+    }
+}

--- a/src/Mollie/GetMolliePayment.php
+++ b/src/Mollie/GetMolliePayment.php
@@ -1,0 +1,16 @@
+<?php
+declare(strict_types=1);
+
+namespace Laravel\Cashier\Mollie;
+
+use Mollie\Api\Resources\Payment;
+use Laravel\Cashier\Mollie\Contracts\GetMolliePayment as Contract;
+
+
+class GetMolliePayment extends BaseMollieInteraction implements Contract
+{
+    public function execute(string $id): Payment
+    {
+        return $this->mollie->payments()->get($id);
+    }
+}

--- a/src/Mollie/RegistersMollieInteractions.php
+++ b/src/Mollie/RegistersMollieInteractions.php
@@ -16,6 +16,7 @@ trait RegistersMollieInteractions
             Contracts\GetMollieMandate::class => GetMollieMandate::class,
             Contracts\GetMolliePayment::class => GetMolliePayment::class,
             Contracts\GetMollieMethodMinimumAmount::class => GetMollieMethodMinimumAmount::class,
+            Contracts\UpdateMolliePayment::class => UpdateMolliePayment::class,
         ]);
 
        $interactions->each(function ($concrete, $abstract) use ($app) {

--- a/src/Mollie/RegistersMollieInteractions.php
+++ b/src/Mollie/RegistersMollieInteractions.php
@@ -15,6 +15,7 @@ trait RegistersMollieInteractions
             Contracts\GetMollieCustomer::class => GetMollieCustomer::class,
             Contracts\GetMollieMandate::class => GetMollieMandate::class,
             Contracts\GetMolliePayment::class => GetMolliePayment::class,
+            Contracts\GetMollieMethodMinimumAmount::class => GetMollieMethodMinimumAmount::class,
         ]);
 
        $interactions->each(function ($concrete, $abstract) use ($app) {

--- a/src/Mollie/RegistersMollieInteractions.php
+++ b/src/Mollie/RegistersMollieInteractions.php
@@ -1,0 +1,24 @@
+<?php
+declare(strict_types=1);
+
+namespace Laravel\Cashier\Mollie;
+
+use Illuminate\Contracts\Foundation\Application;
+
+trait RegistersMollieInteractions
+{
+    protected function registerMollieInteractions(Application $app)
+    {
+        $interactions = collect([
+            Contracts\CreateMollieCustomer::class => CreateMollieCustomer::class,
+            Contracts\CreateMolliePayment::class => CreateMolliePayment::class,
+            Contracts\GetMollieCustomer::class => GetMollieCustomer::class,
+            Contracts\GetMollieMandate::class => GetMollieMandate::class,
+            Contracts\GetMolliePayment::class => GetMolliePayment::class,
+        ]);
+
+       $interactions->each(function ($concrete, $abstract) use ($app) {
+            $app->bind($abstract, $concrete);
+        });
+    }
+}

--- a/src/Mollie/UpdateMolliePayment.php
+++ b/src/Mollie/UpdateMolliePayment.php
@@ -1,0 +1,15 @@
+<?php
+declare(strict_types=1);
+
+namespace Laravel\Cashier\Mollie;
+
+use Mollie\Api\Resources\Payment;
+use Laravel\Cashier\Mollie\Contracts\UpdateMolliePayment as Contract;
+
+class UpdateMolliePayment extends BaseMollieInteraction implements Contract
+{
+    public function execute(Payment $dirtyPayment): Payment
+    {
+        return $dirtyPayment->update();
+    }
+}

--- a/src/Order/Contracts/MinimumPayment.php
+++ b/src/Order/Contracts/MinimumPayment.php
@@ -12,11 +12,4 @@ interface MinimumPayment
      * @return \Money\Money
      */
     public static function forMollieMandate(Mandate $mandate, $currency);
-
-    /**
-     * @param string $mandateId
-     * @param string $currency
-     * @return \Money\Money
-     */
-    public static function forMollieMandateId(string $mandateId, string $currency);
 }

--- a/src/Order/OrderItem.php
+++ b/src/Order/OrderItem.php
@@ -13,6 +13,9 @@ use Laravel\Cashier\Traits\HasOwner;
  * @property InteractsWithOrderItems orderable
  * @property \Carbon\Carbon process_at
  * @property int quantity
+ * @property string currency
+ * @property int unit_price
+ * @property float tax_percentage
  * @property string orderable_type
  * @property mixed orderable_id
  * @method static create(array $array)

--- a/tests/BaseTestCase.php
+++ b/tests/BaseTestCase.php
@@ -5,15 +5,14 @@ namespace Laravel\Cashier\Tests;
 use Carbon\Carbon;
 use GuzzleHttp\Client;
 use Illuminate\Support\Collection;
-use Laravel\Cashier\Coupon\Contracts\CouponHandler;
 use Laravel\Cashier\Coupon\Contracts\CouponRepository;
 use Laravel\Cashier\Coupon\Coupon;
 use Laravel\Cashier\Coupon\FixedDiscountHandler;
 use Laravel\Cashier\Tests\Database\Migrations\CreateUsersTable;
-use Laravel\Cashier\Tests\FirstPayment\Actions\StartSubscriptionTest;
 use Laravel\Cashier\Tests\Fixtures\User;
 use Mockery;
 use Mollie\Api\MollieApiClient;
+use Mollie\Laravel\Wrappers\MollieApiWrapper;
 use Money\Money;
 use Orchestra\Testbench\TestCase;
 
@@ -31,6 +30,8 @@ abstract class BaseTestCase extends TestCase
 
         config(['cashier.webhook_url' => 'https://www.example.com/webhook']);
         config(['cashier.first_payment.webhook_url' => 'https://www.example.com/mandate-webhook']);
+
+        $this->mock(MollieApiWrapper::class, null); // TODO temporary check
     }
 
     /**

--- a/tests/BaseTestCase.php
+++ b/tests/BaseTestCase.php
@@ -18,6 +18,8 @@ use Orchestra\Testbench\TestCase;
 
 abstract class BaseTestCase extends TestCase
 {
+    protected $interactWithMollieAPI = false;
+
     /**
      * Setup the test environment.
      */
@@ -31,7 +33,10 @@ abstract class BaseTestCase extends TestCase
         config(['cashier.webhook_url' => 'https://www.example.com/webhook']);
         config(['cashier.first_payment.webhook_url' => 'https://www.example.com/mandate-webhook']);
 
-        $this->mock(MollieApiWrapper::class, null); // TODO temporary check
+        if(! $this->interactWithMollieAPI) {
+            // Disable the Mollie API
+            $this->mock(MollieApiWrapper::class, null);
+        }
     }
 
     /**
@@ -231,14 +236,14 @@ abstract class BaseTestCase extends TestCase
     protected function getMandatedUser($persist = true, $overrides = [])
     {
         return $this->getCustomerUser($persist, array_merge([
-            'mollie_mandate_id' => $this->getMandateId(),
+            'mollie_mandate_id' => 'mdt_unique_mandate_id',
         ], $overrides));
     }
 
     protected function getCustomerUser($persist = true, $overrides = [])
     {
         return $this->getUser($persist, array_merge([
-            'mollie_customer_id' => $this->getMandatedCustomerId(),
+            'mollie_customer_id' => 'cst_unique_customer_id',
         ], $overrides));
     }
 

--- a/tests/BaseTestCase.php
+++ b/tests/BaseTestCase.php
@@ -340,7 +340,7 @@ abstract class BaseTestCase extends TestCase
         }
 
         return $this->mock(CouponRepository::class, function ($mock) use ($coupon) {
-            $mock->shouldReceive('findOrFail')->with($coupon->name())->andReturn($coupon);
+            return $mock->shouldReceive('findOrFail')->with($coupon->name())->andReturn($coupon);
         });
     }
 

--- a/tests/BillableTest.php
+++ b/tests/BillableTest.php
@@ -190,7 +190,7 @@ class BillableTest extends BaseTestCase
     {
         $this->mock(GetMollieMandate::class, function ($mock) {
             $mandate = new Mandate(new MollieApiClient);
-            $mandate->id = 'mdt_unique_revoked_mandate_id';
+            $mandate->id = 'mdt_unique_mandate_id';
             $mandate->status = 'valid';
             $mandate->method = 'directdebit';
 

--- a/tests/BillableTest.php
+++ b/tests/BillableTest.php
@@ -6,9 +6,14 @@ use Illuminate\Support\Facades\Event;
 use Laravel\Cashier\Coupon\RedeemedCoupon;
 use Laravel\Cashier\Coupon\RedeemedCouponCollection;
 use Laravel\Cashier\Events\MandateClearedFromBillable;
+use Laravel\Cashier\Mollie\Contracts\GetMollieCustomer;
+use Laravel\Cashier\Mollie\Contracts\GetMollieMandate;
 use Laravel\Cashier\SubscriptionBuilder\FirstPaymentSubscriptionBuilder;
 use Laravel\Cashier\SubscriptionBuilder\MandatedSubscriptionBuilder;
 use Laravel\Cashier\Tests\Fixtures\User;
+use Mollie\Api\MollieApiClient;
+use Mollie\Api\Resources\Customer;
+use Mollie\Api\Resources\Mandate;
 
 class BillableTest extends BaseTestCase
 {
@@ -39,10 +44,13 @@ class BillableTest extends BaseTestCase
     {
         $this->withConfiguredPlans();
         $this->withPackageMigrations();
+        $this->withMockedGetMollieCustomer();
+        $this->withMockedGetMollieMandateRevoked();
 
-        $revokedMandateId = 'mdt_MvfK2PRzNJ';
-
-        $user = $this->getUser(false, ['mollie_mandate_id' => $revokedMandateId]);
+        $user = $this->getUser(false, [
+            'mollie_mandate_id' => 'mdt_unique_revoked_mandate_id',
+            'mollie_customer_id' => 'cst_unique_customer_id',
+        ]);
 
         $builder = $user->newSubscription('default', 'monthly-10-1');
 
@@ -53,7 +61,12 @@ class BillableTest extends BaseTestCase
     public function returnsDefaultSubscriptionBuilderIfOwnerHasValidMandateId()
     {
         $this->withConfiguredPlans();
-        $user = $this->getMandatedUser(false);
+        $this->withMockedGetMollieCustomer();
+        $this->withMockedGetMollieMandate();
+        $user = $this->getMandatedUser(false, [
+            'mollie_mandate_id' => 'mdt_unique_mandate_id',
+            'mollie_customer_id' => 'cst_unique_customer_id',
+        ]);
 
         $builder = $user->newSubscription('default', 'monthly-10-1');
 
@@ -78,8 +91,13 @@ class BillableTest extends BaseTestCase
         $this->withPackageMigrations();
         $this->withConfiguredPlans();
         $this->withMockedCouponRepository(); // 'test-coupon'
+        $this->withMockedGetMollieCustomerTwice();
+        $this->withMockedGetMollieMandateTwice();
 
-        $user = $this->getMandatedUser();
+        $user = $this->getMandatedUser(true, [
+            'mollie_mandate_id' => 'mdt_unique_mandate_id',
+            'mollie_customer_id' => 'cst_unique_customer_id',
+        ]);
         $subscription = $user->newSubscription('default', 'monthly-10-1')->create();
         $this->assertEquals(0, $user->redeemedCoupons()->count());
 
@@ -97,8 +115,14 @@ class BillableTest extends BaseTestCase
         $this->withPackageMigrations();
         $this->withConfiguredPlans();
         $this->withMockedCouponRepository(); // 'test-coupon'
+        $this->withMockedGetMollieCustomerTwice();
+        $this->withMockedGetMollieMandateTwice();
 
-        $user = $this->getMandatedUser();
+        $user = $this->getMandatedUser(true, [
+            'mollie_mandate_id' => 'mdt_unique_mandate_id',
+            'mollie_customer_id' => 'cst_unique_customer_id',
+        ]);
+
         $subscription = $user->newSubscription('default', 'monthly-10-1')->create();
         $subscription->redeemedCoupons()->saveMany(factory(RedeemedCoupon::class, 2)->make());
         $this->assertEquals(2, $subscription->redeemedCoupons()->active()->count());
@@ -131,4 +155,58 @@ class BillableTest extends BaseTestCase
         });
     }
 
+    protected function withMockedGetMollieCustomer(): void
+    {
+        $this->mock(GetMollieCustomer::class, function ($mock) {
+            $customer = new Customer(new MollieApiClient);
+            $customer->id = 'cst_unique_customer_id';
+
+            return $mock->shouldReceive('execute')->with('cst_unique_customer_id')->once()->andReturn($customer);
+        });
+    }
+
+    protected function withMockedGetMollieCustomerTwice(): void
+    {
+        $this->mock(GetMollieCustomer::class, function ($mock) {
+            $customer = new Customer(new MollieApiClient);
+            $customer->id = 'cst_unique_customer_id';
+
+            return $mock->shouldReceive('execute')->with('cst_unique_customer_id')->twice()->andReturn($customer);
+        });
+    }
+
+    protected function withMockedGetMollieMandateRevoked(): void
+    {
+        $this->mock(GetMollieMandate::class, function ($mock) {
+            $mandate = new Mandate(new MollieApiClient);
+            $mandate->id = 'mdt_unique_revoked_mandate_id';
+            $mandate->status = 'invalid';
+
+            return $mock->shouldReceive('execute')->with('cst_unique_customer_id', 'mdt_unique_revoked_mandate_id')->once()->andReturn($mandate);
+        });
+    }
+
+    protected function withMockedGetMollieMandate(): void
+    {
+        $this->mock(GetMollieMandate::class, function ($mock) {
+            $mandate = new Mandate(new MollieApiClient);
+            $mandate->id = 'mdt_unique_revoked_mandate_id';
+            $mandate->status = 'valid';
+            $mandate->method = 'directdebit';
+
+            return $mock->shouldReceive('execute')->with('cst_unique_customer_id', 'mdt_unique_mandate_id')->once()->andReturn($mandate);
+        });
+    }
+
+    protected function withMockedGetMollieMandateTwice(): void
+    {
+        $this->mock(GetMollieMandate::class, function ($mock) {
+            $mandate = new Mandate(new MollieApiClient);
+            $mandate->id = 'mdt_unique_revoked_mandate_id';
+            $mandate->status = 'valid';
+            $mandate->method = 'directdebit';
+
+            return $mock->shouldReceive('execute')->with('cst_unique_customer_id', 'mdt_unique_mandate_id')->twice()->andReturn($mandate);
+        });
+    }
 }

--- a/tests/CashierTest.php
+++ b/tests/CashierTest.php
@@ -4,11 +4,17 @@ namespace Laravel\Cashier\Tests;
 
 use Illuminate\Database\Eloquent\Model;
 use Laravel\Cashier\Cashier;
-use Laravel\Cashier\CashierServiceProvider;
+use Laravel\Cashier\Mollie\Contracts\CreateMolliePayment;
+use Laravel\Cashier\Mollie\Contracts\GetMollieMandate;
+use Laravel\Cashier\Mollie\Contracts\GetMollieMethodMinimumAmount;
+use Laravel\Cashier\Mollie\GetMollieCustomer;
 use Laravel\Cashier\Order\Order;
 use Laravel\Cashier\Order\OrderItem;
 use Laravel\Cashier\Subscription;
 use Laravel\Cashier\Tests\Fixtures\User;
+use Mollie\Api\MollieApiClient;
+use Mollie\Api\Resources\Customer;
+use Mollie\Api\Resources\Mandate;
 
 class CashierTest extends BaseTestCase
 {
@@ -36,7 +42,16 @@ class CashierTest extends BaseTestCase
     /** @test */
     public function testRunningCashierProcessesOpenOrderItems()
     {
-        $user = $this->getMandatedUser(true, ['id' => 1]);
+        $this->withMockedGetMollieCustomer();
+        $this->withMockedGetMollieMandate();
+        $this->withMockedGetMollieMethodMinimumAmount();
+        $this->withMockedCreateMolliePayment();
+
+        $user = $this->getMandatedUser(true, [
+            'id' => 1,
+            'mollie_customer_id' => 'cst_unique_customer_id',
+            'mollie_mandate_id' => 'mdt_unique_mandate_id',
+        ]);
 
         $user->orderItems()->save(factory(OrderItem::class)->states('unlinked', 'processed')->make());
         $user->orderItems()->save(factory(OrderItem::class)->states('unlinked', 'unprocessed')->make());
@@ -53,8 +68,34 @@ class CashierTest extends BaseTestCase
     /** @test */
     public function testRunningCashierProcessesUnprocessedOrderItemsAndSchedulesNext()
     {
-        $user1 = $this->getMandatedUser(true, ['id' => 1]);
-        $user2 = $this->getMandatedUser(true, ['id' => 2]);
+        $this->withMockedGetMollieCustomer([
+            'cst_unique_customer_id_1',
+            'cst_unique_customer_id_2',
+        ]);
+        $this->withMockedGetMollieMandate([
+            [
+                'customerId' => 'cst_unique_customer_id_1',
+                'mandateId' => 'mdt_unique_mandate_id_1',
+            ],
+            [
+                'customerId' => 'cst_unique_customer_id_2',
+                'mandateId' => 'mdt_unique_mandate_id_2',
+            ],
+        ]);
+        $this->withMockedGetMollieMethodMinimumAmount(2);
+        $this->withMockedCreateMolliePayment(2);
+
+        $user1 = $this->getMandatedUser(true, [
+            'id' => 1,
+            'mollie_customer_id' => 'cst_unique_customer_id_1',
+            'mollie_mandate_id' => 'mdt_unique_mandate_id_1',
+        ]);
+
+        $user2 = $this->getMandatedUser(true, [
+            'id' => 2,
+            'mollie_customer_id' => 'cst_unique_customer_id_2',
+            'mollie_mandate_id' => 'mdt_unique_mandate_id_2',
+        ]);
 
         $subscription1 = $user1->subscriptions()->save(factory(Subscription::class)->make());
         $subscription2 = $user2->subscriptions()->save(factory(Subscription::class)->make());
@@ -103,7 +144,19 @@ class CashierTest extends BaseTestCase
     public function canSwapSubscriptionPlan()
     {
         $this->withTestNow('2019-01-01');
-        $user = $this->getMandatedUser(true);
+        $user = $this->getMandatedUser(true, [
+            'id' => 1,
+            'mollie_customer_id' => 'cst_unique_customer_id',
+            'mollie_mandate_id' => 'mdt_unique_mandate_id',
+        ]);
+
+        $this->withMockedGetMollieCustomer(['cst_unique_customer_id'], 4);
+        $this->withMockedGetMollieMandate([[
+            'mandateId' => 'mdt_unique_mandate_id',
+            'customerId' => 'cst_unique_customer_id',
+        ]], 4);
+        $this->withMockedGetMollieMethodMinimumAmount(2);
+        $this->withMockedCreateMolliePayment(2);
 
         $subscription = $user->newSubscription('default', 'monthly-20-1')->create();
 
@@ -227,5 +280,51 @@ class CashierTest extends BaseTestCase
         config(['cashier.webhook_url' => 'webhook/cashier']);
 
         $this->assertEquals('webhook/cashier', Cashier::webhookUrl());
+    }
+
+    protected function withMockedGetMollieCustomer($customerIds = ['cst_unique_customer_id'], $times = 1): void
+    {
+        $this->mock(GetMollieCustomer::class, function ($mock) use ($customerIds, $times) {
+            foreach ($customerIds as $id) {
+                $customer = new Customer(new MollieApiClient);
+                $customer->id = $id;
+                $mock->shouldReceive('execute')->with($id)->times($times)->andReturn($customer);
+            }
+
+            return $mock;
+        });
+    }
+
+    protected function withMockedGetMollieMandate($attributes = [[
+        'mandateId' => 'mdt_unique_mandate_id',
+        'customerId' => 'cst_unique_customer_id',
+    ]], $times = 1): void
+    {
+        $this->mock(GetMollieMandate::class, function ($mock) use ($times, $attributes) {
+            foreach ($attributes as $data) {
+                $mandate = new Mandate(new MollieApiClient);
+                $mandate->id = $data['mandateId'];
+                $mandate->status = 'valid';
+                $mandate->method = 'directdebit';
+
+                $mock->shouldReceive('execute')->with($data['customerId'], $data['mandateId'])->times($times)->andReturn($mandate);
+            }
+
+            return $mock;
+        });
+    }
+
+    protected function withMockedGetMollieMethodMinimumAmount($times = 1): void
+    {
+        $this->mock(GetMollieMethodMinimumAmount::class, function ($mock) use ($times) {
+            return $mock->shouldReceive('execute')->with('directdebit', 'EUR')->times($times)->andReturn(money(100, 'EUR'));
+        });
+    }
+
+    protected function withMockedCreateMolliePayment($times = 1): void
+    {
+        $this->mock(CreateMolliePayment::class, function ($mock) use ($times) {
+            return $mock->shouldReceive('execute')->times($times);
+        });
     }
 }

--- a/tests/FirstPayment/FirstPaymentBuilderTest.php
+++ b/tests/FirstPayment/FirstPaymentBuilderTest.php
@@ -5,10 +5,13 @@ namespace Laravel\Cashier\Tests\FirstPayment;
 use Laravel\Cashier\FirstPayment\Actions\AddBalance;
 use Laravel\Cashier\FirstPayment\Actions\AddGenericOrderItem;
 use Laravel\Cashier\FirstPayment\FirstPaymentBuilder;
+use Laravel\Cashier\Mollie\Contracts\CreateMollieCustomer;
 use Laravel\Cashier\Mollie\Contracts\CreateMolliePayment;
+use Laravel\Cashier\Mollie\GetMollieCustomer;
 use Laravel\Cashier\Tests\BaseTestCase;
 use Laravel\Cashier\Tests\Fixtures\User;
 use Mollie\Api\MollieApiClient;
+use Mollie\Api\Resources\Customer;
 use Mollie\Api\Resources\Payment;
 use Mollie\Api\Types\SequenceType;
 
@@ -18,6 +21,13 @@ class FirstPaymentBuilderTest extends BaseTestCase
     {
         parent::setUp();
         $this->withPackageMigrations();
+        $customer = new Customer(new MollieApiClient);
+        $customer->id = 'cst_unique_customer_id';
+
+        $this->mock(CreateMollieCustomer::class, function ($mock) use ($customer) {
+            return $mock->shouldReceive('execute')
+                ->andReturn($customer);
+        });
     }
 
     /** @test */

--- a/tests/FirstPayment/FirstPaymentBuilderTest.php
+++ b/tests/FirstPayment/FirstPaymentBuilderTest.php
@@ -5,8 +5,10 @@ namespace Laravel\Cashier\Tests\FirstPayment;
 use Laravel\Cashier\FirstPayment\Actions\AddBalance;
 use Laravel\Cashier\FirstPayment\Actions\AddGenericOrderItem;
 use Laravel\Cashier\FirstPayment\FirstPaymentBuilder;
+use Laravel\Cashier\Mollie\Contracts\CreateMolliePayment;
 use Laravel\Cashier\Tests\BaseTestCase;
 use Laravel\Cashier\Tests\Fixtures\User;
+use Mollie\Api\MollieApiClient;
 use Mollie\Api\Resources\Payment;
 use Mollie\Api\Types\SequenceType;
 
@@ -82,10 +84,8 @@ class FirstPaymentBuilderTest extends BaseTestCase
                 ],
             ],
         ];
+
         $this->assertEquals($payload, $check_payload);
-
-
-
         $this->assertNotEmpty($customerId);
         $this->assertEquals(0, $owner->orderItems()->count());
         $this->assertEquals(0, $owner->orders()->count());
@@ -116,18 +116,20 @@ class FirstPaymentBuilderTest extends BaseTestCase
             ),
         ]);
 
+        $this->mock(CreateMolliePayment::class, function (CreateMolliePayment $mock) {
+            $payment = new Payment(new MollieApiClient);
+
+            return $mock->shouldReceive('execute')
+                ->once()
+                ->andReturn($payment);
+        });
+
         $payment = $builder->create();
 
         $this->assertEquals(0, $owner->orderItems()->count());
         $this->assertEquals(0, $owner->orders()->count());
 
         $this->assertInstanceOf(Payment::class, $payment);
-
-        // For creating a new paid first payment, use:
-        // dd(
-        //     $payment->getCheckoutUrl(), // visit this Mollie checkout url and set status to 'paid'
-        //     $payment->id // store this in phpunit.xml: MANDATE_PAYMENT_PAID_ID
-        // );
     }
 
     /** @test */
@@ -139,10 +141,20 @@ class FirstPaymentBuilderTest extends BaseTestCase
             'redirectUrl' => 'https://www.example.com/{payment_id}',
         ]);
 
+        $this->mock(CreateMolliePayment::class, function (CreateMolliePayment $mock) {
+            $payment = new Payment(new MollieApiClient);
+            $payment->redirectUrl = 'https://www.example.com/{payment_id}';
+            $payment->id = 'tr_unique_id';
+
+            return $mock->shouldReceive('execute')
+                ->once()
+                ->andReturn($payment);
+        });
+
         $payment = $builder->inOrderTo([
             new AddGenericOrderItem($owner, money(100, 'EUR'), 'Parse redirectUrl test'),
         ])->create();
 
-        $this->assertStringContainsString($payment->id, $payment->redirectUrl);
+        $this->assertEquals('https://www.example.com/tr_unique_id', $payment->redirectUrl);
     }
 }

--- a/tests/FirstPayment/FirstPaymentHandlerTest.php
+++ b/tests/FirstPayment/FirstPaymentHandlerTest.php
@@ -8,6 +8,9 @@ use Laravel\Cashier\FirstPayment\Actions\AddBalance;
 use Laravel\Cashier\FirstPayment\FirstPaymentHandler;
 use Laravel\Cashier\Order\Order;
 use Laravel\Cashier\Tests\BaseTestCase;
+use Laravel\Cashier\Tests\Fixtures\User;
+use Mollie\Api\MollieApiClient;
+use Mollie\Api\Resources\Payment;
 
 class FirstPaymentHandlerTest extends BaseTestCase
 {
@@ -17,11 +20,11 @@ class FirstPaymentHandlerTest extends BaseTestCase
         $this->withPackageMigrations();
         Event::fake();
 
-        $payment = $this->getMandatePayment();
+        $payment = $this->getMandatePaymentStub();
 
-        $owner = factory($payment->metadata->owner->type)->create([
+        $owner = factory(User::class)->create([
             'id' => $payment->metadata->owner->id,
-            'mollie_customer_id' => $this->getMandatedCustomerId(),
+            'mollie_customer_id' => 'cst_unique_customer_id',
         ]);
 
         $handler = new FirstPaymentHandler($payment);
@@ -72,5 +75,43 @@ class FirstPaymentHandlerTest extends BaseTestCase
 
             return true;
         });
+    }
+
+    protected function getMandatePaymentStub(): Payment
+    {
+        $payment = new Payment(new MollieApiClient());
+        $payment->sequenceType = 'first';
+        $payment->id = 'tr_unique_mandate_payment_id';
+        $payment->customerId = 'cst_unique_customer_id';
+        $payment->mandateId = 'mdt_unique_mandate_id';
+        $payment->amount = (object) ['value' => '10.00', 'currency' => 'EUR'];
+        $payment->metadata = json_decode(json_encode([
+            'owner' => [
+                'type' => User::class,
+                'id' => 1,
+            ],
+            'actions' => [
+                [
+                    'handler' => AddBalance::class,
+                    'description' => 'Test add balance 1',
+                    'subtotal' => [
+                        'currency' => 'EUR',
+                        'value' => '5.00',
+                    ],
+                    'taxPercentage' => 0,
+                ],
+                [
+                    'handler' => AddBalance::class,
+                    'description' => 'Test add balance 2',
+                    'subtotal' => [
+                        'currency' => 'EUR',
+                        'value' => '5.00',
+                    ],
+                    'taxPercentage' => 0,
+                ],
+            ],
+        ]));
+
+        return $payment;
     }
 }

--- a/tests/Http/Controllers/WebhookControllerTest.php
+++ b/tests/Http/Controllers/WebhookControllerTest.php
@@ -26,7 +26,7 @@ class WebhookControllerTest extends BaseTestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->controller = new WebhookController;
+        $this->controller = $this->app->make(WebhookController::class);
         $this->payment_paid_id = env('PAYMENT_PAID_ID');
         $this->payment_failed_id = env('PAYMENT_FAILED_ID');
         $this->assertNotNull($this->payment_paid_id);

--- a/tests/Http/Controllers/WebhookControllerTest.php
+++ b/tests/Http/Controllers/WebhookControllerTest.php
@@ -8,6 +8,7 @@ use Laravel\Cashier\Events\OrderPaymentFailed;
 use Laravel\Cashier\Events\OrderPaymentPaid;
 use Laravel\Cashier\Events\SubscriptionCancelled;
 use Laravel\Cashier\Http\Controllers\WebhookController;
+use Laravel\Cashier\Mollie\Contracts\GetMolliePayment;
 use Laravel\Cashier\Order\Order;
 use Laravel\Cashier\Order\OrderItemCollection;
 use Laravel\Cashier\Subscription;
@@ -15,44 +16,72 @@ use Laravel\Cashier\Tests\BaseTestCase;
 use Laravel\Cashier\Tests\Fixtures\User;
 use Laravel\Cashier\Types\SubscriptionCancellationReason;
 use Mollie\Api\Exceptions\ApiException;
+use Mollie\Api\MollieApiClient;
 use Mollie\Api\Resources\Payment;
 
 class WebhookControllerTest extends BaseTestCase
 {
-    private $controller;
-    private $payment_paid_id;
-    private $payment_failed_id;
-
-    protected function setUp(): void
+    /** @test */
+    public function retrievesPaymentResource()
     {
-        parent::setUp();
-        $this->controller = $this->app->make(WebhookController::class);
-        $this->payment_paid_id = env('PAYMENT_PAID_ID');
-        $this->payment_failed_id = env('PAYMENT_FAILED_ID');
-        $this->assertNotNull($this->payment_paid_id);
-        $this->assertNotNull($this->payment_failed_id);
+        $id = 'tr_123xyz';
+
+        $this->mock(GetMolliePayment::class, function (GetMolliePayment $mock) use ($id) {
+            return $mock->shouldReceive('execute')
+                ->with($id)
+                ->once()
+                ->andReturn(new Payment(new MollieApiClient));
+        });
+
+        $this->assertInstanceOf(Payment::class, $this->getController()->getPaymentById($id));
     }
 
     /** @test **/
-    public function onlyRetrievesPaymentResources()
+    public function MollieApiExceptionIsCatchedWhenDebugDisabled()
     {
-        $this->assertInstanceOf(Payment::class, $this->controller->getPaymentById($this->payment_paid_id));
+        $wrongId = 'sub_xxxxxxxxxxx';
+        $this->mock(GetMolliePayment::class, function(GetMolliePayment $mock) use ($wrongId) {
+            return $mock->shouldReceive('execute')
+                ->with($wrongId)
+                ->once()
+                ->andThrow(new ApiException);
+        });
 
         $this->assertFalse(config('app.debug'));
-        $this->assertNull($this->controller->getPaymentById('sub_xxxxxxxxxxx'));
+        $this->assertNull($this->getController()->getPaymentById($wrongId));
+    }
 
-        // Assert that in debug mode an ApiException is thrown
+    /** @test **/
+    public function MollieApiExceptionIsThrownWhenDebugEnabled()
+    {
+        $wrongId = 'sub_xxxxxxxxxxx';
+        $this->mock(GetMolliePayment::class, function(GetMolliePayment $mock) use ($wrongId) {
+            return $mock->shouldReceive('execute')
+                ->with($wrongId)
+                ->once()
+                ->andThrow(new ApiException);
+        });
+
         config(['app.debug' => true]);
+        $this->assertTrue(config('app.debug'));
         $this->expectException(ApiException::class);
-        $this->assertNull($this->controller->getPaymentById('sub_xxxxxxxxxxx'));
+        $this->assertNull($this->getController()->getPaymentById($wrongId));
     }
 
     /** @test **/
     public function handlesUnexistingIdGracefully()
     {
-        $request = $this->getWebhookRequest('tr_xxxxxxxxxxxxx');
+        $id = 'tr_xxxxxxxxxxxxx';
+        $request = $this->getWebhookRequest($id);
 
-        $response = $this->controller->handleWebhook($request);
+        $this->mock(GetMolliePayment::class, function(GetMolliePayment $mock) use ($id) {
+            return $mock->shouldReceive('execute')
+                ->with($id)
+                ->once()
+                ->andThrow(new ApiException);
+        });
+
+        $response = $this->getController()->handleWebhook($request);
 
         $this->assertEquals(200, $response->getStatusCode());
     }
@@ -71,8 +100,10 @@ class WebhookControllerTest extends BaseTestCase
         ]));
         $item = $subscription->scheduleNewOrderItemAt(now());
 
+        $paymentId = 'tr_failed_payment_id';
+
         $order = Order::createFromItems(new OrderItemCollection([$item]), [
-            'mollie_payment_id' => $this->payment_failed_id,
+            'mollie_payment_id' => $paymentId,
             'mollie_payment_status' => 'open',
             'balance_before' => 500,
             'credit_used' => 500,
@@ -81,9 +112,21 @@ class WebhookControllerTest extends BaseTestCase
 
         $this->assertFalse($user->hasCredit('EUR'));
 
-        $request = $this->getWebhookRequest($this->payment_failed_id);
+        $request = $this->getWebhookRequest($paymentId);
 
-        $response = $this->makeTestResponse($this->controller->handleWebhook($request));
+        $this->mock(GetMolliePayment::class, function(GetMolliePayment $mock) use ($paymentId) {
+            $payment = new Payment(new MollieApiClient);
+            $payment->id = $paymentId;
+            $payment->status = 'failed';
+
+            return $mock
+                ->shouldReceive('execute')
+                ->with($paymentId)
+                ->once()
+                ->andReturn($payment);
+        });
+
+        $response = $this->makeTestResponse($this->getController()->handleWebhook($request));
 
         $response->assertStatus(200);
 
@@ -124,14 +167,29 @@ class WebhookControllerTest extends BaseTestCase
         $item = $subscription->scheduleNewOrderItemAt(now());
 
         $order = Order::createFromItems(new OrderItemCollection([$item]));
+
+        $paymentId = 'tr_payment_paid_id';
+
         $order->update([
-            'mollie_payment_id' => $this->payment_paid_id,
+            'mollie_payment_id' => $paymentId,
             'mollie_payment_status' => 'open',
         ]);
 
-        $request = $this->getWebhookRequest($this->payment_paid_id);
+        $request = $this->getWebhookRequest($paymentId);
 
-        $response = $this->controller->handleWebhook($request);
+        $this->mock(GetMolliePayment::class, function(GetMolliePayment $mock) use ($paymentId) {
+            $payment = new Payment(new MollieApiClient);
+            $payment->id = $paymentId;
+            $payment->status = 'paid';
+
+            return $mock
+                ->shouldReceive('execute')
+                ->with($paymentId)
+                ->once()
+                ->andReturn($payment);
+        });
+
+        $response = $this->getController()->handleWebhook($request);
 
         $this->assertEquals(200, $response->getStatusCode());
         $this->assertEquals('paid', $order->fresh()->mollie_payment_status);
@@ -148,18 +206,37 @@ class WebhookControllerTest extends BaseTestCase
         $this->withPackageMigrations();
         Event::fake();
 
+        $paymentId = 'tr_payment_paid_id';
+
         factory(Order::class)->create([
-            'mollie_payment_id' => $this->payment_paid_id,
+            'mollie_payment_id' => $paymentId,
             'mollie_payment_status' => 'paid',
         ]);
 
-        $request = $this->getWebhookRequest($this->payment_paid_id);
+        $request = $this->getWebhookRequest($paymentId);
 
-        $response = $this->controller->handleWebhook($request);
+        $this->mock(GetMolliePayment::class, function(GetMolliePayment $mock) use ($paymentId) {
+            $payment = new Payment(new MollieApiClient);
+            $payment->id = $paymentId;
+            $payment->status = 'paid';
+
+            return $mock
+                ->shouldReceive('execute')
+                ->with($paymentId)
+                ->once()
+                ->andReturn($payment);
+        });
+
+        $response = $this->getController()->handleWebhook($request);
 
         $this->assertEquals(200, $response->getStatusCode());
         Event::assertNotDispatched(OrderPaymentPaid::class);
         Event::assertNotDispatched(OrderPaymentFailed::class);
+    }
+
+    protected function getController(): WebhookController
+    {
+        return $this->app->make(WebhookController::class);
     }
 
     /**

--- a/tests/ManageSubscriptionTest.php
+++ b/tests/ManageSubscriptionTest.php
@@ -8,9 +8,17 @@ use Laravel\Cashier\Cashier;
 use Laravel\Cashier\Events\SubscriptionResumed;
 use Laravel\Cashier\Events\SubscriptionStarted;
 use Laravel\Cashier\Events\SubscriptionQuantityUpdated;
+use Laravel\Cashier\Mollie\Contracts\CreateMolliePayment;
+use Laravel\Cashier\Mollie\Contracts\GetMollieMandate;
+use Laravel\Cashier\Mollie\Contracts\GetMollieMethodMinimumAmount;
+use Laravel\Cashier\Mollie\GetMollieCustomer;
 use Laravel\Cashier\Order\OrderItem;
 use Laravel\Cashier\Subscription;
 use Laravel\Cashier\Tests\Fixtures\User;
+use Mollie\Api\MollieApiClient;
+use Mollie\Api\Resources\Customer;
+use Mollie\Api\Resources\Mandate;
+use Mollie\Api\Resources\Payment;
 
 class ManageSubscriptionTest extends BaseTestCase
 {
@@ -28,7 +36,17 @@ class ManageSubscriptionTest extends BaseTestCase
      */
     public function canCreateDirectDebitSubscriptionForMandatedCustomer()
     {
+        $this->withMockedGetMollieCustomer('cst_unique_customer_id', 5);
+        $this->withMockedGetMollieMandate([[
+            'mandateId' => 'mdt_unique_mandate_id',
+            'customerId' => 'cst_unique_customer_id',
+        ]], 5);
+        $this->withMockedGetMollieMethodMinimumAmount(4);
+        $this->withMockedCreateMolliePayment(4);
+
         $user = $this->getMandatedUser(true, [
+            'mollie_mandate_id' => 'mdt_unique_mandate_id',
+            'mollie_customer_id' => 'cst_unique_customer_id',
             'tax_percentage' => 10,
             'trial_ends_at' => now()->addWeek(),
         ]);
@@ -39,7 +57,7 @@ class ManageSubscriptionTest extends BaseTestCase
 
         Event::fake();
 
-        $user->newSubscriptionForMandateId($this->getMandateId(), 'main', 'monthly-10-1')->create();
+        $user->newSubscriptionForMandateId('mdt_unique_mandate_id', 'main', 'monthly-10-1')->create();
 
         $subscription = $user->subscription('main')->fresh();
 
@@ -210,12 +228,21 @@ class ManageSubscriptionTest extends BaseTestCase
 
     public function testCreatingSubscriptionWithTrial()
     {
-        $user = factory(User::class)->create([
-            'mollie_customer_id' => $this->getMandatedCustomerId(),
+        $this->withMockedGetMollieCustomer('cst_unique_customer_id', 1);
+        $this->withMockedGetMollieMandate([[
+            'mandateId' => 'mdt_unique_mandate_id',
+            'customerId' => 'cst_unique_customer_id',
+        ]], 1);
+
+        $user = $this->getMandatedUser(true, [
+            'mollie_mandate_id' => 'mdt_unique_mandate_id',
+            'mollie_customer_id' => 'cst_unique_customer_id',
+            'tax_percentage' => 10,
+            'trial_ends_at' => now()->addWeek(),
         ]);
 
         // Create Subscription
-        $user->newSubscriptionForMandateId($this->getMandateId(), 'main', 'monthly-10-1')
+        $user->newSubscriptionForMandateId('mdt_unique_mandate_id', 'main', 'monthly-10-1')
             ->trialDays(7)
             ->create();
 
@@ -278,5 +305,51 @@ class ManageSubscriptionTest extends BaseTestCase
         $this->assertTrue($user->onTrial());
         $user->trial_ends_at = Carbon::today()->subDays(5);
         $this->assertFalse($user->onGenericTrial());
+    }
+
+    protected function withMockedGetMollieCustomer($customerId = 'cst_unique_customer_id', $times = 1): void
+    {
+        $this->mock(GetMollieCustomer::class, function ($mock) use ($customerId, $times) {
+            $customer = new Customer(new MollieApiClient);
+            $customer->id = $customerId;
+
+            return $mock->shouldReceive('execute')->with($customerId)->times($times)->andReturn($customer);
+        });
+    }
+
+    protected function withMockedGetMollieMandate($attributes = [[
+        'mandateId' => 'mdt_unique_mandate_id',
+        'customerId' => 'cst_unique_customer_id',
+    ]], $times = 1): void
+    {
+        $this->mock(GetMollieMandate::class, function ($mock) use ($times, $attributes) {
+            foreach ($attributes as $data) {
+                $mandate = new Mandate(new MollieApiClient);
+                $mandate->id = $data['mandateId'];
+                $mandate->status = 'valid';
+                $mandate->method = 'directdebit';
+
+                $mock->shouldReceive('execute')->with($data['customerId'], $data['mandateId'])->times($times)->andReturn($mandate);
+            }
+
+            return $mock;
+        });
+    }
+
+    protected function withMockedGetMollieMethodMinimumAmount($times = 1): void
+    {
+        $this->mock(GetMollieMethodMinimumAmount::class, function ($mock) use ($times) {
+            return $mock->shouldReceive('execute')->with('directdebit', 'EUR')->times($times)->andReturn(money(100, 'EUR'));
+        });
+    }
+
+    protected function withMockedCreateMolliePayment($times = 1): void
+    {
+        $this->mock(CreateMolliePayment::class, function ($mock) use ($times) {
+            $payment = new Payment(new MollieApiClient);
+            $payment->id = 'tr_unique_payment_id';
+
+            return $mock->shouldReceive('execute')->times($times)->andReturn($payment);
+        });
     }
 }

--- a/tests/Mollie/BaseMollieInteractionTest.php
+++ b/tests/Mollie/BaseMollieInteractionTest.php
@@ -1,0 +1,11 @@
+<?php
+declare(strict_types=1);
+
+namespace Laravel\Cashier\Tests\Mollie;
+
+use Laravel\Cashier\Tests\BaseTestCase;
+
+abstract class BaseMollieInteractionTest extends BaseTestCase
+{
+    protected $interactWithMollieAPI = true;
+}

--- a/tests/Mollie/CreateMollieCustomerTest.php
+++ b/tests/Mollie/CreateMollieCustomerTest.php
@@ -4,14 +4,15 @@ declare(strict_types=1);
 namespace Laravel\Cashier\Tests\Mollie;
 
 use Laravel\Cashier\Mollie\Contracts\CreateMollieCustomer;
-use Laravel\Cashier\Tests\BaseTestCase;
 use Mollie\Api\Resources\Customer;
 
-class CreateMollieCustomerTest extends BaseTestCase
+class CreateMollieCustomerTest extends BaseMollieInteractionTest
 {
+    protected $interactWithMollieAPI = true;
+
     /**
      * @test
-     * @group integration
+     * @group mollie_integration
      */
     public function testExecute()
     {

--- a/tests/Mollie/CreateMollieCustomerTest.php
+++ b/tests/Mollie/CreateMollieCustomerTest.php
@@ -1,0 +1,30 @@
+<?php
+declare(strict_types=1);
+
+namespace Laravel\Cashier\Tests\Mollie;
+
+use Laravel\Cashier\Mollie\Contracts\CreateMollieCustomer;
+use Laravel\Cashier\Tests\BaseTestCase;
+use Mollie\Api\Resources\Customer;
+
+class CreateMollieCustomerTest extends BaseTestCase
+{
+    /**
+     * @test
+     * @group integration
+     */
+    public function testExecute()
+    {
+        /** @var CreateMollieCustomer $action */
+        $action = $this->app->make(CreateMollieCustomer::class);
+
+        $result = $action->execute([
+            'email' => 'john@example.com',
+            'name' => 'John Doe',
+        ]);
+
+        $this->assertInstanceOf(Customer::class, $result);
+        $this->assertEquals('john@example.com', $result->email);
+        $this->assertEquals('John Doe', $result->name);
+    }
+}

--- a/tests/Mollie/CreateMolliePaymentTest.php
+++ b/tests/Mollie/CreateMolliePaymentTest.php
@@ -1,0 +1,36 @@
+<?php
+declare(strict_types=1);
+
+namespace Laravel\Cashier\Tests\Mollie;
+
+use Laravel\Cashier\Mollie\Contracts\CreateMolliePayment;
+use Laravel\Cashier\Tests\BaseTestCase;
+use Mollie\Api\Resources\Payment;
+
+class CreateMolliePaymentTest extends BaseTestCase
+{
+    /**
+     * @test
+     * @group integration
+     */
+    public function testExecute()
+    {
+        /** @var CreateMolliePayment $action */
+        $action = $this->app->make(CreateMolliePayment::class);
+
+        $result = $action->execute([
+            'amount' => [
+                'value' => '10.00',
+                'currency' => 'EUR',
+            ],
+            'description' => 'Cashier integration test - CreateMolliePaymentTest',
+            'redirectUrl' => 'https://www.sandervanhooft.com',
+        ]);
+
+        $this->assertInstanceOf(Payment::class, $result);
+        $this->assertEquals('10.00', $result->amount->value);
+        $this->assertEquals('EUR', $result->amount->currency);
+        $this->assertEquals('Cashier integration test - CreateMolliePaymentTest', $result->description);
+        $this->assertEquals('https://www.sandervanhooft.com', $result->redirectUrl);
+    }
+}

--- a/tests/Mollie/CreateMolliePaymentTest.php
+++ b/tests/Mollie/CreateMolliePaymentTest.php
@@ -4,14 +4,13 @@ declare(strict_types=1);
 namespace Laravel\Cashier\Tests\Mollie;
 
 use Laravel\Cashier\Mollie\Contracts\CreateMolliePayment;
-use Laravel\Cashier\Tests\BaseTestCase;
 use Mollie\Api\Resources\Payment;
 
-class CreateMolliePaymentTest extends BaseTestCase
+class CreateMolliePaymentTest extends BaseMollieInteractionTest
 {
     /**
      * @test
-     * @group integration
+     * @group mollie_integration
      */
     public function testExecute()
     {

--- a/tests/Mollie/GetMollieCustomerTest.php
+++ b/tests/Mollie/GetMollieCustomerTest.php
@@ -4,14 +4,13 @@ declare(strict_types=1);
 namespace Laravel\Cashier\Tests\Mollie;
 
 use Laravel\Cashier\Mollie\Contracts\GetMollieCustomer;
-use Laravel\Cashier\Tests\BaseTestCase;
 use Mollie\Api\Resources\Customer;
 
-class GetMollieCustomerTest extends BaseTestCase
+class GetMollieCustomerTest extends BaseMollieInteractionTest
 {
     /**
      * @test
-     * @group integration
+     * @group mollie_integration
      */
     public function testExecute()
     {

--- a/tests/Mollie/GetMollieCustomerTest.php
+++ b/tests/Mollie/GetMollieCustomerTest.php
@@ -1,0 +1,26 @@
+<?php
+declare(strict_types=1);
+
+namespace Laravel\Cashier\Tests\Mollie;
+
+use Laravel\Cashier\Mollie\Contracts\GetMollieCustomer;
+use Laravel\Cashier\Tests\BaseTestCase;
+use Mollie\Api\Resources\Customer;
+
+class GetMollieCustomerTest extends BaseTestCase
+{
+    /**
+     * @test
+     * @group integration
+     */
+    public function testExecute()
+    {
+        /** @var GetMollieCustomer $action */
+        $action = $this->app->make(GetMollieCustomer::class);
+        $id = $this->getMandatedCustomerId();
+        $result = $action->execute($id);
+
+        $this->assertInstanceOf(Customer::class, $result);
+        $this->assertEquals($id, $result->id);
+    }
+}

--- a/tests/Mollie/GetMollieMandateTest.php
+++ b/tests/Mollie/GetMollieMandateTest.php
@@ -1,0 +1,27 @@
+<?php
+declare(strict_types=1);
+
+namespace Laravel\Cashier\Tests\Mollie;
+
+use Laravel\Cashier\Mollie\Contracts\GetMollieMandate;
+use Laravel\Cashier\Tests\BaseTestCase;
+use Mollie\Api\Resources\Mandate;
+
+class GetMollieMandateTest extends BaseTestCase
+{
+    /**
+     * @test
+     * @group integration
+     */
+    public function testExecute()
+    {
+        /** @var \Laravel\Cashier\Mollie\GetMollieMandate $action */
+        $action = $this->app->make(GetMollieMandate::class);
+        $customerId = $this->getMandatedCustomerId();
+        $mandateId = $this->getMandateId();
+        $result = $action->execute($customerId, $mandateId);
+
+        $this->assertInstanceOf(Mandate::class, $result);
+        $this->assertEquals($mandateId, $result->id);
+    }
+}

--- a/tests/Mollie/GetMollieMandateTest.php
+++ b/tests/Mollie/GetMollieMandateTest.php
@@ -4,14 +4,13 @@ declare(strict_types=1);
 namespace Laravel\Cashier\Tests\Mollie;
 
 use Laravel\Cashier\Mollie\Contracts\GetMollieMandate;
-use Laravel\Cashier\Tests\BaseTestCase;
 use Mollie\Api\Resources\Mandate;
 
-class GetMollieMandateTest extends BaseTestCase
+class GetMollieMandateTest extends BaseMollieInteractionTest
 {
     /**
      * @test
-     * @group integration
+     * @group mollie_integration
      */
     public function testExecute()
     {

--- a/tests/Mollie/GetMolliePaymentTest.php
+++ b/tests/Mollie/GetMolliePaymentTest.php
@@ -4,14 +4,13 @@ declare(strict_types=1);
 namespace Laravel\Cashier\Tests\Mollie;
 
 use Laravel\Cashier\Mollie\Contracts\GetMolliePayment;
-use Laravel\Cashier\Tests\BaseTestCase;
 use Mollie\Api\Resources\Payment;
 
-class GetMolliePaymentTest extends BaseTestCase
+class GetMolliePaymentTest extends BaseMollieInteractionTest
 {
     /**
      * @test
-     * @group integration
+     * @group mollie_integration
      */
     public function testExecute()
     {

--- a/tests/Mollie/GetMolliePaymentTest.php
+++ b/tests/Mollie/GetMolliePaymentTest.php
@@ -1,0 +1,26 @@
+<?php
+declare(strict_types=1);
+
+namespace Laravel\Cashier\Tests\Mollie;
+
+use Laravel\Cashier\Mollie\Contracts\GetMolliePayment;
+use Laravel\Cashier\Tests\BaseTestCase;
+use Mollie\Api\Resources\Payment;
+
+class GetMolliePaymentTest extends BaseTestCase
+{
+    /**
+     * @test
+     * @group integration
+     */
+    public function testExecute()
+    {
+        /** @var GetMolliePayment $action */
+        $action = $this->app->make(GetMolliePayment::class);
+        $id = $this->getMandatePaymentID();
+        $result = $action->execute($id);
+
+        $this->assertInstanceOf(Payment::class, $result);
+        $this->assertEquals($id, $result->id);
+    }
+}

--- a/tests/Mollie/UpdateMolliePaymentTest.php
+++ b/tests/Mollie/UpdateMolliePaymentTest.php
@@ -1,0 +1,37 @@
+<?php
+declare(strict_types=1);
+
+namespace Laravel\Cashier\Tests\Mollie;
+
+use Illuminate\Support\Str;
+use Laravel\Cashier\Mollie\Contracts\UpdateMolliePayment;
+use Laravel\Cashier\Tests\BaseTestCase;
+use Mollie\Api\Resources\Payment;
+
+class UpdateMolliePaymentTest extends BaseTestCase
+{
+    /**
+     * @test
+     * @group integration
+     */
+    public function testExecute()
+    {
+        /** @var UpdateMolliePayment $action */
+        $action = $this->app->make(UpdateMolliePayment::class);
+        $payment = mollie()->payments->get($this->getUpdatablePaymentId());
+        $oldWebhookUrl = $payment->webhookUrl;
+        $newWebhookUrl = 'https://example.com/' .Str::uuid();
+        $payment->webhookUrl = $newWebhookUrl;
+
+        $result = $action->execute($payment);
+
+        $this->assertInstanceOf(Payment::class, $result);
+        $this->assertEquals($newWebhookUrl, $result->webhookUrl);
+        $this->assertNotEquals($oldWebhookUrl, $result->webhookUrl);
+    }
+
+    protected function getUpdatablePaymentId(): string
+    {
+        return 'tr_BfTtmpEGVF';
+    }
+}

--- a/tests/Mollie/UpdateMolliePaymentTest.php
+++ b/tests/Mollie/UpdateMolliePaymentTest.php
@@ -5,14 +5,13 @@ namespace Laravel\Cashier\Tests\Mollie;
 
 use Illuminate\Support\Str;
 use Laravel\Cashier\Mollie\Contracts\UpdateMolliePayment;
-use Laravel\Cashier\Tests\BaseTestCase;
 use Mollie\Api\Resources\Payment;
 
-class UpdateMolliePaymentTest extends BaseTestCase
+class UpdateMolliePaymentTest extends BaseMollieInteractionTest
 {
     /**
      * @test
-     * @group integration
+     * @group mollie_integration
      */
     public function testExecute()
     {

--- a/tests/SubscriptionBuilder/FirstPaymentSubscriptionBuilderTest.php
+++ b/tests/SubscriptionBuilder/FirstPaymentSubscriptionBuilderTest.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Cashier\Tests\SubscriptionBuilder;
 
+use Carbon\Carbon;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Facades\Event;
 use Laravel\Cashier\Cashier;
@@ -11,9 +12,16 @@ use Laravel\Cashier\Events\SubscriptionStarted;
 use Laravel\Cashier\Exceptions\CouponException;
 use Laravel\Cashier\FirstPayment\Actions\AddGenericOrderItem;
 use Laravel\Cashier\FirstPayment\Actions\StartSubscription;
+use Laravel\Cashier\Mollie\Contracts\CreateMolliePayment;
+use Laravel\Cashier\Mollie\Contracts\GetMollieCustomer;
+use Laravel\Cashier\Mollie\Contracts\GetMollieMandate;
+use Laravel\Cashier\Mollie\Contracts\GetMolliePayment;
 use Laravel\Cashier\SubscriptionBuilder\FirstPaymentSubscriptionBuilder;
 use Laravel\Cashier\SubscriptionBuilder\RedirectToCheckoutResponse;
 use Laravel\Cashier\Tests\BaseTestCase;
+use Mollie\Api\MollieApiClient;
+use Mollie\Api\Resources\Customer;
+use Mollie\Api\Resources\Mandate;
 use Mollie\Api\Resources\Payment;
 
 class FirstPaymentSubscriptionBuilderTest extends BaseTestCase
@@ -27,7 +35,10 @@ class FirstPaymentSubscriptionBuilderTest extends BaseTestCase
         $this->withTestNow('2019-01-01');
         $this->withPackageMigrations();
         $this->withConfiguredPlans();
-        $this->user = $this->getCustomerUser(true, ['tax_percentage' => 20]);
+        $this->user = $this->getCustomerUser(true, [
+            'tax_percentage' => 20,
+            'mollie_customer_id' => 'cst_unique_customer_id',
+        ]);
     }
 
     /** @test */
@@ -38,6 +49,10 @@ class FirstPaymentSubscriptionBuilderTest extends BaseTestCase
         $firstPayment["webhook_url"] = "https://foo-webhook-bar.com";
         config(["cashier_plans.plans.monthly-10-1.first_payment" => $firstPayment]);
         config(["cashier.locale" => "nl_NL"]);
+
+        $this->withMockedGetMollieCustomerTwice();
+
+        $this->withMockedCreateMolliePayment();
 
         $builder = $this->getBuilder()
             ->nextPaymentAt(now()->addDays(12))
@@ -95,18 +110,15 @@ class FirstPaymentSubscriptionBuilderTest extends BaseTestCase
                 ],
             ],
         ], $payload);
-
-        // For creating a new paid first payment, use:
-        // dd(
-        //     $response->payment()->getCheckoutUrl(), // visit this Mollie checkout url and set status to 'paid'
-        //     $response->payment()->id // store this in phpunit.xml: SUBSCRIPTION_MANDATE_PAYMENT_PAID_ID
-        // );
     }
 
     /** @test */
     public function handlesQuantity()
     {
         config(['cashier.locale' => 'nl_NL']);
+
+        $this->withMockedGetMollieCustomerTwice();
+        $this->withMockedCreateMolliePayment();
 
         $builder = $this->getBuilder()->quantity(3);
 
@@ -133,11 +145,68 @@ class FirstPaymentSubscriptionBuilderTest extends BaseTestCase
 
         Event::fake();
 
+        $this->mock(GetMolliePayment::class, function ($mock) {
+            $payment = new Payment(new MollieApiClient);
+            $payment->id = 'tr_unique_payment_id';
+            $payment->paidAt = Carbon::now()->toIso8601String();
+            $payment->mandateId = 'mdt_unique_mandate_id';
+            $payment->metadata = json_decode(json_encode([
+                "owner" => [
+                    "type" => get_class($this->user),
+                    "id" => 1,
+                ],
+                "actions" => [
+                    [
+                        "handler" => StartSubscription::class,
+                        "description" => "Monthly payment",
+                        "subtotal" => [
+                            "value" => "0.00",
+                            "currency" => "EUR",
+                        ],
+                        "taxPercentage" => 20,
+                        "plan" => "monthly-10-1",
+                        "name" => "default",
+                        "quantity" => 1,
+                        "nextPaymentAt" => now()->addDays(12)->toIso8601String(),
+                        "trialUntil" => now()->addDays(5)->toIso8601String(),
+                    ],
+                    [
+                        "handler" => AddGenericOrderItem::class,
+                        "description" => "Test mandate payment",
+                        "subtotal" => [
+                            "value" => "0.04",
+                            "currency" => "EUR",
+                        ],
+                        "taxPercentage" => 20,
+                    ],
+                ],
+            ]));
+
+            return $mock->shouldReceive('execute')
+                ->with('tr_unique_payment_id')
+                ->once()
+                ->andReturn($payment);
+        });
+
+        $this->mock(GetMollieMandate::class, function ($mock) {
+            $mandate = new Mandate(new MollieApiClient);
+            $mandate->id = 'mdt_unique_mandate_id';
+            $mandate->status = 'valid';
+            $mandate->method = 'directdebit';
+
+            return $mock->shouldReceive('execute')
+                ->with('cst_unique_customer_id', 'mdt_unique_mandate_id')
+                ->once()
+                ->andReturn($mandate);
+        });
+
+        $this->withMockedGetMollieCustomer();
+
         $this->assertFalse($this->user->subscribed());
         $this->assertNull($this->user->mollie_mandate_id);
 
         $response = $this->post(route('webhooks.mollie.first_payment', [
-            'id' => $this->getSubscriptionMandatePaymentID()
+            'id' => 'tr_unique_payment_id'
         ]));
 
         $response->assertStatus(200);
@@ -178,6 +247,9 @@ class FirstPaymentSubscriptionBuilderTest extends BaseTestCase
     public function testWithCouponNoTrialModifiesThePaymentAmount()
     {
         $this->withMockedCouponRepository();
+        $this->withMockedCreateMolliePayment();
+        $this->withMockedGetMollieCustomerTwice();
+
         $builder = $this->getBuilder()->withCoupon('test-coupon');
         $builder->create();
 
@@ -188,18 +260,29 @@ class FirstPaymentSubscriptionBuilderTest extends BaseTestCase
     }
 
     /** @test */
-    public function testSkipTrialRevertsTheTrialAmount()
+    public function testHandlesTrialDays()
     {
+        $this->withMockedCreateMolliePayment();
+        $this->withMockedGetMollieCustomerTwice();
         $trialBuilder = $this->getBuilder();
 
         $trialBuilder->trialDays(5)->create();
+
         $this->assertEquals(
             '0.05',
             $trialBuilder->getMandatePaymentBuilder()->getMolliePayload()['amount']['value']
         );
+    }
 
+    /** @test */
+    public function testHandlesNoTrialMode()
+    {
+        $this->withMockedCreateMolliePayment();
+        $this->withMockedGetMollieCustomerTwice();
         $skipTrialBuilder = $this->getBuilder()->trialDays(5)->skipTrial();
+
         $skipTrialBuilder->create();
+
         $this->assertEquals(
             '12.00',
             $skipTrialBuilder->getMandatePaymentBuilder()->getMolliePayload()['amount']['value']
@@ -216,5 +299,47 @@ class FirstPaymentSubscriptionBuilderTest extends BaseTestCase
             'default',
             'monthly-10-1'
         );
+    }
+
+    protected function withMockedGetMollieCustomer()
+    {
+        $this->mock(GetMollieCustomer::class, function ($mock) {
+            $customer = new Customer(new MollieApiClient);
+            $customer->id = 'cst_unique_customer_id';
+
+            return $mock->shouldReceive('execute')
+                ->with('cst_unique_customer_id')
+                ->once()
+                ->andReturn($customer);
+        });
+    }
+
+    protected function withMockedGetMollieCustomerTwice()
+    {
+        $this->mock(GetMollieCustomer::class, function ($mock) {
+            $customer = new Customer(new MollieApiClient);
+            $customer->id = 'cst_unique_customer_id';
+
+            return $mock->shouldReceive('execute')
+                ->with('cst_unique_customer_id')
+                ->twice()
+                ->andReturn($customer);
+        });
+    }
+
+    protected function withMockedCreateMolliePayment(): void
+    {
+        $this->mock(CreateMolliePayment::class, function ($mock) {
+            $payment = new Payment(new MollieApiClient);
+            $payment->id = 'tr_unique_payment_id';
+            $payment->_links = json_decode(json_encode([
+                'checkout' => [
+                    'href' => 'https://foo-redirect-bar.com',
+                    'type' => 'text/html',
+                ],
+            ]));
+
+            return $mock->shouldReceive('execute')->once()->andReturn($payment);
+        });
     }
 }

--- a/tests/SubscriptionBuilder/MandatedSubscriptionBuilderTest.php
+++ b/tests/SubscriptionBuilder/MandatedSubscriptionBuilderTest.php
@@ -34,26 +34,8 @@ class MandatedSubscriptionBuilderTest extends BaseTestCase
     public function testWithCouponNoTrial()
     {
         $this->withMockedCouponRepository();
-        $this->mock(GetMollieMandate::class, function ($mock) {
-            $mandate = new Mandate(new MollieApiClient);
-            $mandate->id = 'mdt_unique_mandate_id';
-            $mandate->status = 'valid';
-            $mandate->method = 'directdebit';
-
-            return $mock->shouldReceive('execute')
-                ->with('cst_unique_customer_id', 'mdt_unique_mandate_id')
-                ->once()
-                ->andReturn($mandate);
-        });
-        $this->mock(GetMollieCustomer::class, function ($mock) {
-            $customer = new Customer(new MollieApiClient);
-            $customer->id = 'cst_unique_customer_id';
-
-            return $mock->shouldReceive('execute')
-                ->with('cst_unique_customer_id')
-                ->once()
-                ->andReturn($customer);
-        });
+        $this->withMockedGetMollieMandate();
+        $this->withMockedGetMollieCustomer();
         $now = Carbon::parse('2019-01-01');
         $this->withTestNow($now);
 
@@ -79,26 +61,8 @@ class MandatedSubscriptionBuilderTest extends BaseTestCase
     public function testWithCouponAndTrial()
     {
         $this->withMockedCouponRepository();
-        $this->mock(GetMollieMandate::class, function ($mock) {
-            $mandate = new Mandate(new MollieApiClient);
-            $mandate->id = 'mdt_unique_mandate_id';
-            $mandate->status = 'valid';
-            $mandate->method = 'directdebit';
-
-            return $mock->shouldReceive('execute')
-                ->with('cst_unique_customer_id', 'mdt_unique_mandate_id')
-                ->once()
-                ->andReturn($mandate);
-        });
-        $this->mock(GetMollieCustomer::class, function ($mock) {
-            $customer = new Customer(new MollieApiClient);
-            $customer->id = 'cst_unique_customer_id';
-
-            return $mock->shouldReceive('execute')
-                ->with('cst_unique_customer_id')
-                ->once()
-                ->andReturn($customer);
-        });
+        $this->withMockedGetMollieMandate();
+        $this->withMockedGetMollieCustomer();
         $now = Carbon::parse('2019-01-01');
         $this->withTestNow($now);
 
@@ -129,26 +93,8 @@ class MandatedSubscriptionBuilderTest extends BaseTestCase
     {
         $this->expectException(CouponException::class);
         $this->withMockedCouponRepository(null, new InvalidatingCouponHandler);
-        $this->mock(GetMollieMandate::class, function ($mock) {
-            $mandate = new Mandate(new MollieApiClient);
-            $mandate->id = 'mdt_unique_mandate_id';
-            $mandate->status = 'valid';
-            $mandate->method = 'directdebit';
-
-            return $mock->shouldReceive('execute')
-                ->with('cst_unique_customer_id', 'mdt_unique_mandate_id')
-                ->once()
-                ->andReturn($mandate);
-        });
-        $this->mock(GetMollieCustomer::class, function ($mock) {
-            $customer = new Customer(new MollieApiClient);
-            $customer->id = 'cst_unique_customer_id';
-
-            return $mock->shouldReceive('execute')
-                ->with('cst_unique_customer_id')
-                ->once()
-                ->andReturn($customer);
-        });
+        $this->withMockedGetMollieMandate();
+        $this->withMockedGetMollieCustomer();
         $this->getBuilder()->withCoupon('test-coupon')->create();
     }
 
@@ -173,5 +119,27 @@ class MandatedSubscriptionBuilderTest extends BaseTestCase
             'default',
             'monthly-10-1'
         );
+    }
+
+    protected function withMockedGetMollieCustomer(): void
+    {
+        $this->mock(GetMollieCustomer::class, function ($mock) {
+            $customer = new Customer(new MollieApiClient);
+            $customer->id = 'cst_unique_customer_id';
+
+            return $mock->shouldReceive('execute')->with('cst_unique_customer_id')->once()->andReturn($customer);
+        });
+    }
+
+    protected function withMockedGetMollieMandate(): void
+    {
+        $this->mock(GetMollieMandate::class, function ($mock) {
+            $mandate = new Mandate(new MollieApiClient);
+            $mandate->id = 'mdt_unique_mandate_id';
+            $mandate->status = 'valid';
+            $mandate->method = 'directdebit';
+
+            return $mock->shouldReceive('execute')->with('cst_unique_customer_id', 'mdt_unique_mandate_id')->once()->andReturn($mandate);
+        });
     }
 }

--- a/tests/SubscriptionBuilder/MandatedSubscriptionBuilderTest.php
+++ b/tests/SubscriptionBuilder/MandatedSubscriptionBuilderTest.php
@@ -6,8 +6,13 @@ use Carbon\Carbon;
 use Laravel\Cashier\Coupon\AppliedCoupon;
 use Laravel\Cashier\Coupon\RedeemedCoupon;
 use Laravel\Cashier\Exceptions\CouponException;
+use Laravel\Cashier\Mollie\Contracts\GetMollieCustomer;
+use Laravel\Cashier\Mollie\Contracts\GetMollieMandate;
 use Laravel\Cashier\SubscriptionBuilder\MandatedSubscriptionBuilder;
 use Laravel\Cashier\Tests\BaseTestCase;
+use Mollie\Api\MollieApiClient;
+use Mollie\Api\Resources\Customer;
+use Mollie\Api\Resources\Mandate;
 
 class MandatedSubscriptionBuilderTest extends BaseTestCase
 {
@@ -18,13 +23,37 @@ class MandatedSubscriptionBuilderTest extends BaseTestCase
         parent::setUp();
         $this->withPackageMigrations();
         $this->withConfiguredPlans();
-        $this->user = $this->getMandatedUser(true);
+        $this->user = $this->getCustomerUser(true, [
+            'tax_percentage' => 20,
+            'mollie_customer_id' => 'cst_unique_customer_id',
+            'mollie_mandate_id' => 'mdt_unique_mandate_id',
+        ]);
     }
 
     /** @test */
     public function testWithCouponNoTrial()
     {
         $this->withMockedCouponRepository();
+        $this->mock(GetMollieMandate::class, function ($mock) {
+            $mandate = new Mandate(new MollieApiClient);
+            $mandate->id = 'mdt_unique_mandate_id';
+            $mandate->status = 'valid';
+            $mandate->method = 'directdebit';
+
+            return $mock->shouldReceive('execute')
+                ->with('cst_unique_customer_id', 'mdt_unique_mandate_id')
+                ->once()
+                ->andReturn($mandate);
+        });
+        $this->mock(GetMollieCustomer::class, function ($mock) {
+            $customer = new Customer(new MollieApiClient);
+            $customer->id = 'cst_unique_customer_id';
+
+            return $mock->shouldReceive('execute')
+                ->with('cst_unique_customer_id')
+                ->once()
+                ->andReturn($customer);
+        });
         $now = Carbon::parse('2019-01-01');
         $this->withTestNow($now);
 
@@ -50,6 +79,26 @@ class MandatedSubscriptionBuilderTest extends BaseTestCase
     public function testWithCouponAndTrial()
     {
         $this->withMockedCouponRepository();
+        $this->mock(GetMollieMandate::class, function ($mock) {
+            $mandate = new Mandate(new MollieApiClient);
+            $mandate->id = 'mdt_unique_mandate_id';
+            $mandate->status = 'valid';
+            $mandate->method = 'directdebit';
+
+            return $mock->shouldReceive('execute')
+                ->with('cst_unique_customer_id', 'mdt_unique_mandate_id')
+                ->once()
+                ->andReturn($mandate);
+        });
+        $this->mock(GetMollieCustomer::class, function ($mock) {
+            $customer = new Customer(new MollieApiClient);
+            $customer->id = 'cst_unique_customer_id';
+
+            return $mock->shouldReceive('execute')
+                ->with('cst_unique_customer_id')
+                ->once()
+                ->andReturn($customer);
+        });
         $now = Carbon::parse('2019-01-01');
         $this->withTestNow($now);
 
@@ -80,6 +129,26 @@ class MandatedSubscriptionBuilderTest extends BaseTestCase
     {
         $this->expectException(CouponException::class);
         $this->withMockedCouponRepository(null, new InvalidatingCouponHandler);
+        $this->mock(GetMollieMandate::class, function ($mock) {
+            $mandate = new Mandate(new MollieApiClient);
+            $mandate->id = 'mdt_unique_mandate_id';
+            $mandate->status = 'valid';
+            $mandate->method = 'directdebit';
+
+            return $mock->shouldReceive('execute')
+                ->with('cst_unique_customer_id', 'mdt_unique_mandate_id')
+                ->once()
+                ->andReturn($mandate);
+        });
+        $this->mock(GetMollieCustomer::class, function ($mock) {
+            $customer = new Customer(new MollieApiClient);
+            $customer->id = 'cst_unique_customer_id';
+
+            return $mock->shouldReceive('execute')
+                ->with('cst_unique_customer_id')
+                ->once()
+                ->andReturn($customer);
+        });
         $this->getBuilder()->withCoupon('test-coupon')->create();
     }
 

--- a/tests/SubscriptionTest.php
+++ b/tests/SubscriptionTest.php
@@ -5,10 +5,15 @@ namespace Laravel\Cashier\Tests;
 use Carbon\Carbon;
 use Illuminate\Support\Facades\Event;
 use Laravel\Cashier\Events\SubscriptionResumed;
+use Laravel\Cashier\Mollie\Contracts\GetMollieMandate;
+use Laravel\Cashier\Mollie\GetMollieCustomer;
 use Laravel\Cashier\Order\OrderItem;
 use Laravel\Cashier\Subscription;
 use Laravel\Cashier\Tests\Fixtures\User;
 use LogicException;
+use Mollie\Api\MollieApiClient;
+use Mollie\Api\Resources\Customer;
+use Mollie\Api\Resources\Mandate;
 
 class SubscriptionTest extends BaseTestCase
 {
@@ -145,12 +150,15 @@ class SubscriptionTest extends BaseTestCase
     {
         Carbon::setTestNow(Carbon::parse('2018-01-01'));
         $this->withConfiguredPlans();
+        $this->withMockedGetMollieCustomer();
+        $this->withMockedGetMollieMandate();
 
         $user = factory(User::class)->create([
-            'mollie_customer_id' => $this->getMandatedCustomerId(),
+            'mollie_mandate_id' => 'mdt_unique_mandate_id',
+            'mollie_customer_id' => 'cst_unique_customer_id',
         ]);
 
-        $subscription = $user->newSubscriptionForMandateId($this->getMandateId(), 'main', 'monthly-10-1')->create();
+        $subscription = $user->newSubscriptionForMandateId('mdt_unique_mandate_id', 'main', 'monthly-10-1')->create();
         $this->assertCarbon(Carbon::parse('2018-01-01'), $subscription->cycle_started_at);
         $this->assertCarbon(Carbon::parse('2018-01-01'), $subscription->cycle_ends_at);
 
@@ -308,5 +316,34 @@ class SubscriptionTest extends BaseTestCase
 
         $this->assertFalse($subscription->cancelled());
         $this->assertCarbon(now()->addWeek(), $subscription->cycle_ends_at);
+    }
+
+    protected function withMockedGetMollieCustomer($customerId = 'cst_unique_customer_id', $times = 1): void
+    {
+        $this->mock(GetMollieCustomer::class, function ($mock) use ($customerId, $times) {
+            $customer = new Customer(new MollieApiClient);
+            $customer->id = $customerId;
+
+            return $mock->shouldReceive('execute')->with($customerId)->times($times)->andReturn($customer);
+        });
+    }
+
+    protected function withMockedGetMollieMandate($attributes = [[
+        'mandateId' => 'mdt_unique_mandate_id',
+        'customerId' => 'cst_unique_customer_id',
+    ]], $times = 1): void
+    {
+        $this->mock(GetMollieMandate::class, function ($mock) use ($times, $attributes) {
+            foreach ($attributes as $data) {
+                $mandate = new Mandate(new MollieApiClient);
+                $mandate->id = $data['mandateId'];
+                $mandate->status = 'valid';
+                $mandate->method = 'directdebit';
+
+                $mock->shouldReceive('execute')->with($data['customerId'], $data['mandateId'])->times($times)->andReturn($mandate);
+            }
+
+            return $mock;
+        });
     }
 }

--- a/tests/SwapSubscriptionPlanTest.php
+++ b/tests/SwapSubscriptionPlanTest.php
@@ -4,8 +4,15 @@ namespace Laravel\Cashier\Tests;
 
 use Illuminate\Support\Facades\Event;
 use Laravel\Cashier\Events\SubscriptionPlanSwapped;
+use Laravel\Cashier\Mollie\Contracts\CreateMolliePayment;
+use Laravel\Cashier\Mollie\Contracts\GetMollieMandate;
+use Laravel\Cashier\Mollie\Contracts\GetMollieMethodMinimumAmount;
+use Laravel\Cashier\Mollie\GetMollieCustomer;
 use Laravel\Cashier\Order\OrderItem;
 use Laravel\Cashier\Subscription;
+use Mollie\Api\MollieApiClient;
+use Mollie\Api\Resources\Customer;
+use Mollie\Api\Resources\Mandate;
 
 class SwapSubscriptionPlanTest extends BaseTestCase
 {
@@ -24,6 +31,10 @@ class SwapSubscriptionPlanTest extends BaseTestCase
     public function canSwapToAnotherPlan()
     {
         $now = now();
+        $this->withMockedGetMollieCustomer();
+        $this->withMockedGetMollieMandate();
+        $this->withMockedGetMollieMethodMinimumAmount();
+        $this->withMockedCreateMolliePayment();
 
         $user = $this->getUserWithZeroBalance();
         $subscription = $this->getSubscriptionForUser($user);
@@ -167,9 +178,12 @@ class SwapSubscriptionPlanTest extends BaseTestCase
 
     protected function getUserWithZeroBalance()
     {
-        $user = $this->getMandatedUser(true, ["tax_percentage" => 10]);
+        $user = $this->getMandatedUser(true, [
+            'tax_percentage' => 10,
+            'mollie_customer_id' => 'cst_unique_customer_id',
+            'mollie_mandate_id' => 'mdt_unique_mandate_id',
+        ]);
         $this->assertEquals(0, $user->credits()->whereCurrency('EUR')->count());
-        $this->assertTrue($user->asMollieCustomer()->hasValidMandate());
 
         return $user;
     }
@@ -187,5 +201,51 @@ class SwapSubscriptionPlanTest extends BaseTestCase
             "cycle_ends_at" => now()->subWeeks(2)->addMonth(),
             "tax_percentage" => 10,
         ]));
+    }
+
+    protected function withMockedGetMollieCustomer($customerIds = ['cst_unique_customer_id'], $times = 1): void
+    {
+        $this->mock(GetMollieCustomer::class, function ($mock) use ($customerIds, $times) {
+            foreach ($customerIds as $id) {
+                $customer = new Customer(new MollieApiClient);
+                $customer->id = $id;
+                $mock->shouldReceive('execute')->with($id)->times($times)->andReturn($customer);
+            }
+
+            return $mock;
+        });
+    }
+
+    protected function withMockedGetMollieMandate($attributes = [[
+        'mandateId' => 'mdt_unique_mandate_id',
+        'customerId' => 'cst_unique_customer_id',
+    ]], $times = 1): void
+    {
+        $this->mock(GetMollieMandate::class, function ($mock) use ($times, $attributes) {
+            foreach ($attributes as $data) {
+                $mandate = new Mandate(new MollieApiClient);
+                $mandate->id = $data['mandateId'];
+                $mandate->status = 'valid';
+                $mandate->method = 'directdebit';
+
+                $mock->shouldReceive('execute')->with($data['customerId'], $data['mandateId'])->times($times)->andReturn($mandate);
+            }
+
+            return $mock;
+        });
+    }
+
+    protected function withMockedGetMollieMethodMinimumAmount($times = 1): void
+    {
+        $this->mock(GetMollieMethodMinimumAmount::class, function ($mock) use ($times) {
+            return $mock->shouldReceive('execute')->with('directdebit', 'EUR')->times($times)->andReturn(money(100, 'EUR'));
+        });
+    }
+
+    protected function withMockedCreateMolliePayment($times = 1): void
+    {
+        $this->mock(CreateMolliePayment::class, function ($mock) use ($times) {
+            return $mock->shouldReceive('execute')->times($times);
+        });
     }
 }


### PR DESCRIPTION
I've extracted all Mollie interactions into separate classes for easy integration testing.

Also, testing speed has been improved from 45 seconds + timeouts to 15 seconds without any issue.
This should simplify contributing a lot as you can now run the full test suite locally. (The Mollie API integration tests do not run by default.)