### PR TITLE
fix: avoid duplicates in order's owner check

### DIFF
--- a/src/Order/Order.php
+++ b/src/Order/Order.php
@@ -62,15 +62,15 @@ class Order extends Model
     public static function createFromItems(OrderItemCollection $items, $overrides = [], $process_items = true)
     {
         return DB::transaction(function () use ($items, $overrides, $process_items) {
-            if ($process_items) {
+            if($process_items) {
                 $items = $items->preprocess();
             }
 
-            if ($items->currencies()->count() > 1) {
+            if($items->currencies()->count() > 1) {
                 throw new LogicException('Creating an order requires items to have a single currency.');
             }
 
-            if ($items->owners()->unique('id')->count() > 1) {
+            if($items->owners()->unique('id')->count() > 1) {
                 throw new LogicException('Creating an order requires items to have a single owner.');
             }
 
@@ -93,7 +93,7 @@ class Order extends Model
             $items->each(function (OrderItem $item) use ($order, $process_items) {
                 $item->update(['order_id' => $order->id]);
 
-                if ($process_items) {
+                if($process_items) {
                     $item->process();
                 }
             });
@@ -150,7 +150,7 @@ class Order extends Model
             $owner = $this->owner;
 
             // Process user balance, if any
-            if ($this->getTotal()->getAmount() > 0 && $owner->hasCredit($this->currency)) {
+            if($this->getTotal()->getAmount() > 0 && $owner->hasCredit($this->currency)) {
                 $total = $this->getTotal();
                 $this->balance_before = $owner->credit($this->currency)->value;
 
@@ -162,7 +162,7 @@ class Order extends Model
             $minimumPaymentAmount = $this->ensureValidMandateAndMinimumPaymentAmountWhenTotalDuePositive();
             $totalDue = money($this->total_due, $this->currency);
 
-            switch (true) {
+            switch(true) {
                 case $totalDue->isZero():
                     // No payment processing required
                     $this->mollie_payment_id = null;
@@ -243,10 +243,10 @@ class Order extends Model
     public function invoice($id = null, $date = null)
     {
         $invoice = (new Invoice(
-            $this->currency,
-            $id ?: $this->number,
-            $date ?: $this->created_at
-        ))->addItems($this->items)
+                $this->currency,
+                $id ?: $this->number,
+                $date ?: $this->created_at
+            ))->addItems($this->items)
             ->setStartingBalance($this->getBalanceBefore())
             ->setCompletedBalance($this->getBalanceAfter())
             ->setUsedBalance($this->getCreditUsed());
@@ -256,13 +256,13 @@ class Order extends Model
         $extra_information = null;
         $owner = $this->owner;
 
-        if (method_exists($owner, 'getExtraBillingInformation')) {
+        if(method_exists($owner, 'getExtraBillingInformation')) {
             $extra_information = $owner->getExtraBillingInformation();
 
-            if (! empty($extra_information)) {
+            if(! empty($extra_information)) {
                 $extra_information = explode("\n", $extra_information);
 
-                if (is_array($extra_information) && ! empty($extra_information)) {
+                if(is_array($extra_information) && ! empty($extra_information)) {
                     $invoice->setExtraInformation($extra_information);
                 }
             }
@@ -290,7 +290,7 @@ class Order extends Model
      */
     public function scopeProcessed($query, $processed = true)
     {
-        if ($processed) {
+        if($processed) {
             return $query->whereNotNull('processed_at');
         }
 
@@ -363,8 +363,7 @@ class Order extends Model
      *
      * @return bool
      */
-    public function creditApplied()
-    {
+    public function creditApplied() {
         return $this->credit_used <> 0;
     }
 
@@ -378,7 +377,7 @@ class Order extends Model
     public function handlePaymentFailed()
     {
         return DB::transaction(function () {
-            if ($this->creditApplied()) {
+            if($this->creditApplied()) {
                 $this->owner->addCredit($this->getCreditUsed());
             }
 
@@ -490,7 +489,7 @@ class Order extends Model
      */
     protected function guardMandate(?Mandate $mandate)
     {
-        if (empty($mandate) || ! $mandate->isValid()) {
+        if(empty($mandate) || ! $mandate->isValid()) {
             throw new InvalidMandateException('Cannot process payment without valid mandate for order id '.$this->id);
         }
     }

--- a/src/Order/Order.php
+++ b/src/Order/Order.php
@@ -62,15 +62,15 @@ class Order extends Model
     public static function createFromItems(OrderItemCollection $items, $overrides = [], $process_items = true)
     {
         return DB::transaction(function () use ($items, $overrides, $process_items) {
-            if($process_items) {
+            if ($process_items) {
                 $items = $items->preprocess();
             }
 
-            if($items->currencies()->count() > 1) {
+            if ($items->currencies()->count() > 1) {
                 throw new LogicException('Creating an order requires items to have a single currency.');
             }
 
-            if($items->owners()->count() > 1) {
+            if ($items->owners()->unique('id')->count() > 1) {
                 throw new LogicException('Creating an order requires items to have a single owner.');
             }
 
@@ -93,7 +93,7 @@ class Order extends Model
             $items->each(function (OrderItem $item) use ($order, $process_items) {
                 $item->update(['order_id' => $order->id]);
 
-                if($process_items) {
+                if ($process_items) {
                     $item->process();
                 }
             });
@@ -150,7 +150,7 @@ class Order extends Model
             $owner = $this->owner;
 
             // Process user balance, if any
-            if($this->getTotal()->getAmount() > 0 && $owner->hasCredit($this->currency)) {
+            if ($this->getTotal()->getAmount() > 0 && $owner->hasCredit($this->currency)) {
                 $total = $this->getTotal();
                 $this->balance_before = $owner->credit($this->currency)->value;
 
@@ -162,7 +162,7 @@ class Order extends Model
             $minimumPaymentAmount = $this->ensureValidMandateAndMinimumPaymentAmountWhenTotalDuePositive();
             $totalDue = money($this->total_due, $this->currency);
 
-            switch(true) {
+            switch (true) {
                 case $totalDue->isZero():
                     // No payment processing required
                     $this->mollie_payment_id = null;
@@ -243,10 +243,10 @@ class Order extends Model
     public function invoice($id = null, $date = null)
     {
         $invoice = (new Invoice(
-                $this->currency,
-                $id ?: $this->number,
-                $date ?: $this->created_at
-            ))->addItems($this->items)
+            $this->currency,
+            $id ?: $this->number,
+            $date ?: $this->created_at
+        ))->addItems($this->items)
             ->setStartingBalance($this->getBalanceBefore())
             ->setCompletedBalance($this->getBalanceAfter())
             ->setUsedBalance($this->getCreditUsed());
@@ -256,13 +256,13 @@ class Order extends Model
         $extra_information = null;
         $owner = $this->owner;
 
-        if(method_exists($owner, 'getExtraBillingInformation')) {
+        if (method_exists($owner, 'getExtraBillingInformation')) {
             $extra_information = $owner->getExtraBillingInformation();
 
-            if(! empty($extra_information)) {
+            if (! empty($extra_information)) {
                 $extra_information = explode("\n", $extra_information);
 
-                if(is_array($extra_information) && ! empty($extra_information)) {
+                if (is_array($extra_information) && ! empty($extra_information)) {
                     $invoice->setExtraInformation($extra_information);
                 }
             }
@@ -290,7 +290,7 @@ class Order extends Model
      */
     public function scopeProcessed($query, $processed = true)
     {
-        if($processed) {
+        if ($processed) {
             return $query->whereNotNull('processed_at');
         }
 
@@ -363,7 +363,8 @@ class Order extends Model
      *
      * @return bool
      */
-    public function creditApplied() {
+    public function creditApplied()
+    {
         return $this->credit_used <> 0;
     }
 
@@ -377,7 +378,7 @@ class Order extends Model
     public function handlePaymentFailed()
     {
         return DB::transaction(function () {
-            if($this->creditApplied()) {
+            if ($this->creditApplied()) {
                 $this->owner->addCredit($this->getCreditUsed());
             }
 
@@ -489,7 +490,7 @@ class Order extends Model
      */
     protected function guardMandate(?Mandate $mandate)
     {
-        if(empty($mandate) || ! $mandate->isValid()) {
+        if (empty($mandate) || ! $mandate->isValid()) {
             throw new InvalidMandateException('Cannot process payment without valid mandate for order id '.$this->id);
         }
     }


### PR DESCRIPTION
As mentioned in the issue #264 the trial period feature fails due to a wrong check on the Order's owner.

This fix will avoid duplicate owners for a single order, in the `createFromItems` method.

Thank you