### PR TITLE
Fix for route:cache

### DIFF
--- a/src/CashierServiceProvider.php
+++ b/src/CashierServiceProvider.php
@@ -24,10 +24,10 @@ class CashierServiceProvider extends ServiceProvider
      */
     public function boot()
     {
+        $this->mergeConfig();
         if (Cashier::$registersRoutes) {
             $this->loadRoutesFrom(__DIR__.'/../routes/webhooks.php');
         }
-        $this->mergeConfig();
         $this->loadViewsFrom(__DIR__.'/../resources/views', 'cashier');
 
         mollie()->addVersionString('MollieLaravelCashier/' . self::PACKAGE_VERSION);


### PR DESCRIPTION
Fixes the issue with the route:cache command in which the routes get cached from the package instead of the own routes.