### PR TITLE
Support for custom Primary Key

### DIFF
--- a/src/Credit/Credit.php
+++ b/src/Credit/Credit.php
@@ -34,7 +34,7 @@ class Credit extends Model
 
             // if the owner has no credit yet
             return static::create([
-                'owner_id' => $owner->id,
+                'owner_id' => $owner->getKey(),
                 'owner_type' => get_class($owner),
                 'currency' => $amount->getCurrency()->getCode(),
                 'value' => (int) $amount->getAmount(),

--- a/src/FirstPayment/Actions/StartSubscription.php
+++ b/src/FirstPayment/Actions/StartSubscription.php
@@ -146,7 +146,7 @@ class StartSubscription extends BaseAction implements SubscriptionConfigurator
     {
         return [
             'owner_type' => get_class($this->owner),
-            'owner_id' => $this->owner->id,
+            'owner_id' => $this->owner->getKey(),
             'process_at' => now(),
             'description' => $this->getDescription(),
             'currency' => $this->getCurrency(),

--- a/src/FirstPayment/FirstPaymentBuilder.php
+++ b/src/FirstPayment/FirstPaymentBuilder.php
@@ -114,7 +114,7 @@ class FirstPaymentBuilder
             'metadata' => [
                 'owner' => [
                     'type' => get_class($this->owner),
-                    'id' => $this->owner->id,
+                    'id' => $this->owner->getKey(),
                 ],
                 'actions' => $this->actions->toMolliePayload(),
             ],

--- a/src/Order/Order.php
+++ b/src/Order/Order.php
@@ -104,7 +104,7 @@ class Order extends Model
             $total = $items->sum('total');
 
             $order = static::create(array_merge([
-                'owner_id' => $owner->id,
+                'owner_id' => $owner->getKey(),
                 'owner_type' => get_class($owner),
                 'number' => static::numberGenerator()->generate(),
                 'currency' => $currency,

--- a/src/Order/OrderItemCollection.php
+++ b/src/Order/OrderItemCollection.php
@@ -39,7 +39,7 @@ class OrderItemCollection extends Collection
     public function whereOwner($owner)
     {
         return $this->filter(function ($item) use ($owner) {
-            return (string) $item->owner_id === (string) $owner->id
+            return (string) $item->owner_id === (string) $owner->getKey()
                 && $item->owner_type === get_class($owner);
         });
     }
@@ -52,9 +52,9 @@ class OrderItemCollection extends Collection
     public function chunkByOwner()
     {
         return $this->owners()->sortBy(function ($owner) {
-            return get_class($owner) . '_' . $owner->id;
+            return get_class($owner) . '_' . $owner->getKey();
         })->mapWithKeys(function ($owner) {
-            $key = get_class($owner) . '_' . $owner->id;
+            $key = get_class($owner) . '_' . $owner->getKey();
 
             return [$key => $this->whereOwner($owner)];
         });

--- a/src/Payment.php
+++ b/src/Payment.php
@@ -71,7 +71,7 @@ class Payment extends Model
             'mollie_payment_id' => $payment->id,
             'mollie_payment_status' => $payment->status,
             'owner_type' => $owner->getMorphClass(),
-            'owner_id' => $owner->id,
+            'owner_id' => $owner->getKey(),
             'currency' => $payment->amount->currency,
             'amount' => (int) mollie_object_to_money($payment->amount)->getAmount(),
             'amount_refunded' => (int) $amountRefunded->getAmount(),

--- a/src/Traits/HasOwner.php
+++ b/src/Traits/HasOwner.php
@@ -25,7 +25,7 @@ trait HasOwner
     public function scopeWhereOwner($query, $owner)
     {
         return $query
-            ->where('owner_id', $owner->id)
+            ->where('owner_id', $owner->getKey())
             ->where('owner_type', get_class($owner));
     }
 }

--- a/tests/FirstPayment/FirstPaymentBuilderTest.php
+++ b/tests/FirstPayment/FirstPaymentBuilderTest.php
@@ -70,7 +70,7 @@ class FirstPaymentBuilderTest extends BaseTestCase
             'metadata' => [
                 'owner' => [
                     'type' => get_class($owner),
-                    'id' => $owner->id,
+                    'id' => $owner->getKey(),
                 ],
                 'actions' => [
                     [


### PR DESCRIPTION
Billable, instead of `$owner->id` it uses `$owner->getKey()` and in the payload we need to keep id:
```php
{
  "owner": {
    "type": "App\\Models\\User",
    "id": 1 // this is the primary key value (steam_id, etc)
  },
  ...
```

if we rename payload `owner -> id` we can't use old payloads.

I think this is the best solution.

