### PR TITLE
Add note on v2 in mollie/laravel-cashier-mollie

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+## Version 2
+**The updated v2 of this package has been released under a new namespace.  Please check out [mollie/laravel-cashier-mollie](https://github.com/mollie/laravel-cashier-mollie) to find latest version.**
+
 <p align="center">
   <img src="https://info.mollie.com/hubfs/github/laravel-cashier/logoLaravel.jpg" width="128" height="128"/>
 </p>


### PR DESCRIPTION
This PR adds a notice to the README about the recently released v2 of this package.
At the moment it is not directly obvious that there is a newer version, because it was released in a different namespace / Github organization.